### PR TITLE
Repos are now pulled into unique temp directory

### DIFF
--- a/catalog.spec
+++ b/catalog.spec
@@ -35,7 +35,7 @@ module Catalog {
     dev version of the module (old dev versions are not stored, but you can always reregister an old
     version from the repo) and start a build.
     */
-    funcdef register_repo(RegisterRepoParams params) returns (int timestamp) authentication required;
+    funcdef register_repo(RegisterRepoParams params) returns (string registration_id) authentication required;
 
     /* immediately updates the beta tag to what is currently in dev, whatever is currently in beta
     is discarded.  Will fail if a release request is active and has not been approved/denied */
@@ -49,7 +49,7 @@ module Catalog {
         string git_url;
         string git_commit_hash;
         string git_commit_message;
-        string timestamp;
+        int timestamp;
         list <string> owners;
     } RequestedReleaseInfo;
 
@@ -174,9 +174,9 @@ module Catalog {
     funcdef get_module_state(SelectOneModuleParams params) returns (ModuleState state);
 
     /*
-        given the timestamp returned from the register method, you can check the build log with this method
+        given the registration_id returned from the register method, you can check the build log with this method
     */
-    funcdef get_build_log(int timestamp) returns (string);
+    funcdef get_build_log(string registration_id) returns (string);
 
 
 

--- a/catalog.spec
+++ b/catalog.spec
@@ -187,6 +187,10 @@ module Catalog {
         string new_git_url;
     } UpdateGitUrlParams;
 
+
+    /* admin method to delete a module, will only work if the module has not been released */
+    funcdef delete_module(SelectOneModuleParams params) returns () authentication required;
+
     /* admin method to move the git url for a module, should only be used if the exact same code has migrated to
     a new URL.  It should not be used as a way to change ownership, get updates from a new source, or get a new
     module name for an existing git url because old versions are retained and git commits saved will no longer

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -1392,6 +1392,91 @@ given the registration_id returned from the register method, you can check the b
  
 
 
+=head2 delete_module
+
+  $obj->delete_module($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a Catalog.SelectOneModuleParams
+SelectOneModuleParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	git_url has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a Catalog.SelectOneModuleParams
+SelectOneModuleParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	git_url has a value which is a string
+
+
+=end text
+
+=item Description
+
+admin method to delete a module, will only work if the module has not been released
+
+=back
+
+=cut
+
+ sub delete_module
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function delete_module (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to delete_module:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'delete_module');
+	}
+    }
+
+    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
+	method => "Catalog.delete_module",
+	params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'delete_module',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return;
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method delete_module",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'delete_module',
+				       );
+    }
+}
+ 
+
+
 =head2 migrate_module_to_new_git_url
 
   $obj->migrate_module_to_new_git_url($params)

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -260,7 +260,7 @@ boolean is an int
 
 =head2 register_repo
 
-  $timestamp = $obj->register_repo($params)
+  $registration_id = $obj->register_repo($params)
 
 =over 4
 
@@ -270,7 +270,7 @@ boolean is an int
 
 <pre>
 $params is a Catalog.RegisterRepoParams
-$timestamp is an int
+$registration_id is a string
 RegisterRepoParams is a reference to a hash where the following keys are defined:
 	git_url has a value which is a string
 	git_commit_hash has a value which is a string
@@ -282,7 +282,7 @@ RegisterRepoParams is a reference to a hash where the following keys are defined
 =begin text
 
 $params is a Catalog.RegisterRepoParams
-$timestamp is an int
+$registration_id is a string
 RegisterRepoParams is a reference to a hash where the following keys are defined:
 	git_url has a value which is a string
 	git_commit_hash has a value which is a string
@@ -539,7 +539,7 @@ RequestedReleaseInfo is a reference to a hash where the following keys are defin
 	git_url has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
-	timestamp has a value which is a string
+	timestamp has a value which is an int
 	owners has a value which is a reference to a list where each element is a string
 
 </pre>
@@ -554,7 +554,7 @@ RequestedReleaseInfo is a reference to a hash where the following keys are defin
 	git_url has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
-	timestamp has a value which is a string
+	timestamp has a value which is an int
 	owners has a value which is a reference to a list where each element is a string
 
 
@@ -1313,7 +1313,7 @@ boolean is an int
 
 =head2 get_build_log
 
-  $return = $obj->get_build_log($timestamp)
+  $return = $obj->get_build_log($registration_id)
 
 =over 4
 
@@ -1322,7 +1322,7 @@ boolean is an int
 =begin html
 
 <pre>
-$timestamp is an int
+$registration_id is a string
 $return is a string
 
 </pre>
@@ -1331,7 +1331,7 @@ $return is a string
 
 =begin text
 
-$timestamp is an int
+$registration_id is a string
 $return is a string
 
 
@@ -1339,7 +1339,7 @@ $return is a string
 
 =item Description
 
-given the timestamp returned from the register method, you can check the build log with this method
+given the registration_id returned from the register method, you can check the build log with this method
 
 =back
 
@@ -1357,10 +1357,10 @@ given the timestamp returned from the register method, you can check the build l
 							       "Invalid argument count for function get_build_log (received $n, expecting 1)");
     }
     {
-	my($timestamp) = @args;
+	my($registration_id) = @args;
 
 	my @_bad_arguments;
-        (!ref($timestamp)) or push(@_bad_arguments, "Invalid type for argument 1 \"timestamp\" (value was \"$timestamp\")");
+        (!ref($registration_id)) or push(@_bad_arguments, "Invalid type for argument 1 \"registration_id\" (value was \"$registration_id\")");
         if (@_bad_arguments) {
 	    my $msg = "Invalid arguments passed to get_build_log:\n" . join("", map { "\t$_\n" } @_bad_arguments);
 	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
@@ -2136,7 +2136,7 @@ module_name has a value which is a string
 git_url has a value which is a string
 git_commit_hash has a value which is a string
 git_commit_message has a value which is a string
-timestamp has a value which is a string
+timestamp has a value which is an int
 owners has a value which is a reference to a list where each element is a string
 
 </pre>
@@ -2150,7 +2150,7 @@ module_name has a value which is a string
 git_url has a value which is a string
 git_commit_hash has a value which is a string
 git_commit_message has a value which is a string
-timestamp has a value which is a string
+timestamp has a value which is an int
 owners has a value which is a reference to a list where each element is a string
 
 

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -258,11 +258,11 @@ class Catalog(object):
                           [params], json_rpc_context)
         return resp[0]
   
-    def get_build_log(self, timestamp, json_rpc_context = None):
+    def get_build_log(self, registration_id, json_rpc_context = None):
         if json_rpc_context and type(json_rpc_context) is not dict:
             raise ValueError('Method get_build_log: argument json_rpc_context is not type dict as required.')
         resp = self._call('Catalog.get_build_log',
-                          [timestamp], json_rpc_context)
+                          [registration_id], json_rpc_context)
         return resp[0]
   
     def migrate_module_to_new_git_url(self, params, json_rpc_context = None):

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -265,6 +265,12 @@ class Catalog(object):
                           [registration_id], json_rpc_context)
         return resp[0]
   
+    def delete_module(self, params, json_rpc_context = None):
+        if json_rpc_context and type(json_rpc_context) is not dict:
+            raise ValueError('Method delete_module: argument json_rpc_context is not type dict as required.')
+        self._call('Catalog.delete_module',
+                   [params], json_rpc_context)
+  
     def migrate_module_to_new_git_url(self, params, json_rpc_context = None):
         if json_rpc_context and type(json_rpc_context) is not dict:
             raise ValueError('Method migrate_module_to_new_git_url: argument json_rpc_context is not type dict as required.')

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -223,6 +223,13 @@ class Catalog:
         # return the results
         return [returnVal]
 
+    def delete_module(self, ctx, params):
+        # ctx is the context object
+        #BEGIN delete_module
+        self.cc.delete_module(params,ctx['user_id'])
+        #END delete_module
+        pass
+
     def migrate_module_to_new_git_url(self, ctx, params):
         # ctx is the context object
         #BEGIN migrate_module_to_new_git_url

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -71,17 +71,17 @@ class Catalog:
 
     def register_repo(self, ctx, params):
         # ctx is the context object
-        # return variables are: timestamp
+        # return variables are: registration_id
         #BEGIN register_repo
-        timestamp = self.cc.register_repo(params, ctx['user_id'], ctx['token'])
+        registration_id = self.cc.register_repo(params, ctx['user_id'], ctx['token'])
         #END register_repo
 
         # At some point might do deeper type checking...
-        if not isinstance(timestamp, int):
+        if not isinstance(registration_id, basestring):
             raise ValueError('Method register_repo return value ' +
-                             'timestamp is not type int as required.')
+                             'registration_id is not type basestring as required.')
         # return the results
-        return [timestamp]
+        return [registration_id]
 
     def push_dev_to_beta(self, ctx, params):
         # ctx is the context object
@@ -209,11 +209,11 @@ class Catalog:
         # return the results
         return [state]
 
-    def get_build_log(self, ctx, timestamp):
+    def get_build_log(self, ctx, registration_id):
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN get_build_log
-        returnVal = self.cc.get_build_log(timestamp)
+        returnVal = self.cc.get_build_log(registration_id)
         #END get_build_log
 
         # At some point might do deeper type checking...

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -447,7 +447,7 @@ class Application(object):
         self.method_authentication['Catalog.get_module_state'] = 'none'
         self.rpc_service.add(impl_Catalog.get_build_log,
                              name='Catalog.get_build_log',
-                             types=[int])
+                             types=[basestring])
         self.method_authentication['Catalog.get_build_log'] = 'none'
         self.rpc_service.add(impl_Catalog.migrate_module_to_new_git_url,
                              name='Catalog.migrate_module_to_new_git_url',

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -102,6 +102,9 @@ sync_methods['Catalog.get_module_state'] = True
 async_run_methods['Catalog.get_build_log_async'] = ['Catalog', 'get_build_log']
 async_check_methods['Catalog.get_build_log_check'] = ['Catalog', 'get_build_log']
 sync_methods['Catalog.get_build_log'] = True
+async_run_methods['Catalog.delete_module_async'] = ['Catalog', 'delete_module']
+async_check_methods['Catalog.delete_module_check'] = ['Catalog', 'delete_module']
+sync_methods['Catalog.delete_module'] = True
 async_run_methods['Catalog.migrate_module_to_new_git_url_async'] = ['Catalog', 'migrate_module_to_new_git_url']
 async_check_methods['Catalog.migrate_module_to_new_git_url_check'] = ['Catalog', 'migrate_module_to_new_git_url']
 sync_methods['Catalog.migrate_module_to_new_git_url'] = True
@@ -449,6 +452,10 @@ class Application(object):
                              name='Catalog.get_build_log',
                              types=[basestring])
         self.method_authentication['Catalog.get_build_log'] = 'none'
+        self.rpc_service.add(impl_Catalog.delete_module,
+                             name='Catalog.delete_module',
+                             types=[dict])
+        self.method_authentication['Catalog.delete_module'] = 'required'
         self.rpc_service.add(impl_Catalog.migrate_module_to_new_git_url,
                              name='Catalog.migrate_module_to_new_git_url',
                              types=[dict])

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -502,6 +502,18 @@ class CatalogController:
             log = '[log not found - registration_id is invalid or the log has been deleted]'
         return log
 
+
+    def delete_module(self,params,username):
+        if not self.is_admin(username):
+            raise ValueError('Only Admin users can migrate module git urls.')
+        if 'module_name' not in params and 'git_url' not in params:
+            raise ValueError('You must specify the "module_name" or "git_url" of the module to delete.')
+        params = self.filter_module_or_repo_selection(params)
+        error = self.db.delete_module(module_name=params['module_name'], git_url=params['git_url'])
+        if error is not None:
+            raise ValueError('Delete operation failed - some unknown database error: '+error)
+
+
     def migrate_module_to_new_git_url(self, params, username):
         if not self.is_admin(username):
             raise ValueError('Only Admin users can migrate module git urls.')

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -5,6 +5,7 @@ import threading
 import time
 import copy
 import os
+import random
 
 import biokbase.catalog.version
 
@@ -95,7 +96,24 @@ class CatalogController:
         git_url = params['git_url']
         if not bool(urlparse(git_url).netloc):
             raise ValueError('The git url provided is not a valid URL.')
+        # generate a unique registration ID based on a timestamp in ms + 4 random digits
         timestamp = int((datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds()*1000)
+        registration_id = str(timestamp)+'_'+str(random.randint(1000,9999))
+        tries = 20
+        for t in range(20):
+            try:
+                # keep trying to make the directory until it works
+                os.mkdir(os.path.join(self.temp_dir,registration_id))
+                break
+            except:
+                # if we fail, wait a bit and try again
+                time.sleep(0.002)
+                timestamp = int((datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds()*1000)
+                registration_id = str(timestamp)+'_'+random.randint(1000,9999)
+
+        # if we couldn't reserve a spot for this registration, then quit
+        if not os.path.isdir(os.path.join(self.temp_dir,registration_id)):
+            raise ValueError('Unable to allocate a directory for building.  Try again, and if the problem persists contact us.')
 
         # 0) Make sure the submitter is on the list
         if not self.is_approved_developer([username])[0]:
@@ -137,12 +155,12 @@ class CatalogController:
 
         # first set the dev current_release timestamp
 
-        t = threading.Thread(target=_start_registration, args=(params,timestamp,username,token,self.db, self.temp_dir, self.docker_base_url, 
+        t = threading.Thread(target=_start_registration, args=(params,registration_id,timestamp,username,token,self.db, self.temp_dir, self.docker_base_url, 
             self.docker_registry_host, self.nms_url, self.nms_admin_user, self.nms_admin_psswd, module_details))
         t.start()
 
         # 4) provide the timestamp 
-        return timestamp
+        return registration_id
 
 
 
@@ -476,12 +494,12 @@ class CatalogController:
         return sorted(simple_kbase_dev_list)
 
 
-    def get_build_log(self, timestamp):
+    def get_build_log(self, registration_id):
         try:
-            with open(self.temp_dir+'/registration.log.'+str(timestamp)) as log_file:
+            with open(self.temp_dir+'/registration.log.'+str(registration_id)) as log_file:
                 log = log_file.read()
         except:
-            log = '[log not found - timestamp is invalid or the log has been deleted]'
+            log = '[log not found - registration_id is invalid or the log has been deleted]'
         return log
 
     def migrate_module_to_new_git_url(self, params, username):
@@ -533,8 +551,8 @@ class CatalogController:
 
 
 # NOT PART OF CLASS CATALOG!!
-def _start_registration(params,timestamp,username,token, db, temp_dir, docker_base_url, docker_registry_host, nms_url, nms_admin_user, nms_admin_psswd, module_details):
-    registrar = Registrar(params, timestamp, username, token, db, temp_dir, docker_base_url, docker_registry_host,
+def _start_registration(params,registration_id, timestamp,username,token, db, temp_dir, docker_base_url, docker_registry_host, nms_url, nms_admin_user, nms_admin_psswd, module_details):
+    registrar = Registrar(params, registration_id, timestamp, username, token, db, temp_dir, docker_base_url, docker_registry_host,
                             nms_url, nms_admin_user, nms_admin_psswd, module_details)
     registrar.start_registration()
 

--- a/lib/biokbase/catalog/db.py
+++ b/lib/biokbase/catalog/db.py
@@ -301,6 +301,22 @@ class MongoCatalogDBI:
         result = self.modules.update(query, {'$set':{'git_url':new_git_url.strip()}})
         return self._check_update_result(result)
 
+    def delete_module(self,module_name, git_url):
+        if not module_name and not git_url:
+            raise ValueError('Module name or git url is required to delete a module.')
+        query = self._get_mongo_query(module_name=module_name, git_url=git_url)
+        module_details = self.modules.find_one(query)
+        if not module_details:
+            raise ValueError('No module matches this selection criteria')
+
+        if module_details['current_versions']['release']:
+            raise ValueError('Cannot delete module that has been released.  Make it inactive instead.')
+
+        if module_details['release_versions']:
+            raise ValueError('Cannot delete module that has released versions.  Make it inactive instead.')
+
+        result = self.modules.remove({'_id':module_details['_id']})
+        return self._check_update_result(result)
 
     #### utility methods
     def _get_mongo_query(self, module_name='', git_url=''):

--- a/lib/biokbase/catalog/version.py
+++ b/lib/biokbase/catalog/version.py
@@ -1,2 +1,2 @@
 # File that simply defines version information
-CATALOG_VERSION = '0.0.5'
+CATALOG_VERSION = '0.0.6'

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -377,6 +377,22 @@ public class CatalogClient {
     }
 
     /**
+     * <p>Original spec-file function name: delete_module</p>
+     * <pre>
+     * admin method to delete a module, will only work if the module has not been released
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.catalog.SelectOneModuleParams SelectOneModuleParams}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public void deleteModule(SelectOneModuleParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<Object> retType = new TypeReference<Object>() {};
+        caller.jsonrpcCall("Catalog.delete_module", args, retType, false, true, jsonRpcContext);
+    }
+
+    /**
      * <p>Original spec-file function name: migrate_module_to_new_git_url</p>
      * <pre>
      * admin method to move the git url for a module, should only be used if the exact same code has migrated to

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -183,15 +183,15 @@ public class CatalogClient {
      * version from the repo) and start a build.
      * </pre>
      * @param   params   instance of type {@link us.kbase.catalog.RegisterRepoParams RegisterRepoParams}
-     * @return   parameter "timestamp" of Long
+     * @return   parameter "registration_id" of String
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public Long registerRepo(RegisterRepoParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public String registerRepo(RegisterRepoParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         args.add(params);
-        TypeReference<List<Long>> retType = new TypeReference<List<Long>>() {};
-        List<Long> res = caller.jsonrpcCall("Catalog.register_repo", args, retType, true, true, jsonRpcContext);
+        TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
+        List<String> res = caller.jsonrpcCall("Catalog.register_repo", args, retType, true, true, jsonRpcContext);
         return res.get(0);
     }
 
@@ -361,16 +361,16 @@ public class CatalogClient {
     /**
      * <p>Original spec-file function name: get_build_log</p>
      * <pre>
-     * given the timestamp returned from the register method, you can check the build log with this method
+     * given the registration_id returned from the register method, you can check the build log with this method
      * </pre>
-     * @param   timestamp   instance of Long
+     * @param   registrationId   instance of String
      * @return   instance of String
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public String getBuildLog(Long timestamp, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public String getBuildLog(String registrationId, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
-        args.add(timestamp);
+        args.add(registrationId);
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
         List<String> res = caller.jsonrpcCall("Catalog.get_build_log", args, retType, true, false, jsonRpcContext);
         return res.get(0);

--- a/lib/java/us/kbase/catalog/RequestedReleaseInfo.java
+++ b/lib/java/us/kbase/catalog/RequestedReleaseInfo.java
@@ -38,7 +38,7 @@ public class RequestedReleaseInfo {
     @JsonProperty("git_commit_message")
     private java.lang.String gitCommitMessage;
     @JsonProperty("timestamp")
-    private java.lang.String timestamp;
+    private Long timestamp;
     @JsonProperty("owners")
     private List<String> owners;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
@@ -104,16 +104,16 @@ public class RequestedReleaseInfo {
     }
 
     @JsonProperty("timestamp")
-    public java.lang.String getTimestamp() {
+    public Long getTimestamp() {
         return timestamp;
     }
 
     @JsonProperty("timestamp")
-    public void setTimestamp(java.lang.String timestamp) {
+    public void setTimestamp(Long timestamp) {
         this.timestamp = timestamp;
     }
 
-    public RequestedReleaseInfo withTimestamp(java.lang.String timestamp) {
+    public RequestedReleaseInfo withTimestamp(Long timestamp) {
         this.timestamp = timestamp;
         return this;
     }

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -182,9 +182,9 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             [params], 1, _callback, _errorCallback);
     };
  
-     this.get_build_log = function (timestamp, _callback, _errorCallback) {
-        if (typeof timestamp === 'function')
-            throw 'Argument timestamp can not be a function';
+     this.get_build_log = function (registration_id, _callback, _errorCallback) {
+        if (typeof registration_id === 'function')
+            throw 'Argument registration_id can not be a function';
         if (_callback && typeof _callback !== 'function')
             throw 'Argument _callback must be a function if defined';
         if (_errorCallback && typeof _errorCallback !== 'function')
@@ -192,7 +192,7 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
         if (typeof arguments === 'function' && arguments.length > 1+2)
             throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
         return json_call_ajax("Catalog.get_build_log",
-            [timestamp], 1, _callback, _errorCallback);
+            [registration_id], 1, _callback, _errorCallback);
     };
  
      this.migrate_module_to_new_git_url = function (params, _callback, _errorCallback) {

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -195,6 +195,19 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             [registration_id], 1, _callback, _errorCallback);
     };
  
+     this.delete_module = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.delete_module",
+            [params], 0, _callback, _errorCallback);
+    };
+ 
      this.migrate_module_to_new_git_url = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -14,7 +14,7 @@ class BasicCatalogTest(unittest.TestCase):
 
 
     def test_version(self):
-        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.5'])
+        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.6'])
 
 
     def test_is_registered(self):

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -56,9 +56,9 @@ class CatalogTestUtil:
         self.initialize_mongo()
 
         # 3 setup the scratch space
-        self.scratch_dir = os.path.join(self.test_dir,str(datetime.now()))
+        self.scratch_dir = os.path.join(self.test_dir,'temp_test_files',str(datetime.now()))
         self.log("scratch directory="+self.scratch_dir)
-        os.mkdir(self.scratch_dir)
+        os.makedirs(self.scratch_dir)
 
 
         # 4 startup any dependencies (nms, docker registry?)

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -23,8 +23,9 @@ class CoreRegistrationTest(unittest.TestCase):
         # (1) register the test repo
         giturl = self.cUtil.get_test_repo_1()
         githash = '4ada53f318f69a38276e82d0e841e685aa0c2362' # branch simple_good_repo
-        timestamp = self.catalog.register_repo(self.cUtil.user_ctx(),
+        registration_id = self.catalog.register_repo(self.cUtil.user_ctx(),
             {'git_url':giturl, 'git_commit_hash':githash})[0]
+        timestamp = int(registration_id.split('_')[0])
 
         # (2) check state until error or complete, must be complete, and make sure this was relatively fast
         start = time()
@@ -35,7 +36,7 @@ class CoreRegistrationTest(unittest.TestCase):
                 break
             self.assertTrue(time()-start < timeout, 'simple registration build exceeded timeout of '+str(timeout)+'s')
         self.assertEqual(state['registration'],'complete')
-        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),timestamp)
+        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),registration_id)
         self.assertTrue(log is not None)
 
         # (3) get module info
@@ -230,8 +231,9 @@ class CoreRegistrationTest(unittest.TestCase):
 
         #(9) register again, dev is updated, beta and release are not
         githash2 = '599d796c6b7c30a47b3a8a496346d8f49c29a064' # branch simple_good_repo
-        timestamp2 = self.catalog.register_repo(self.cUtil.user_ctx(),
+        registration_id2 = self.catalog.register_repo(self.cUtil.user_ctx(),
             {'git_url':giturl, 'git_commit_hash':githash2})[0]
+        timestamp2 = int(registration_id2.split('_')[0])
         start = time()
         timeout = 60 #seconds
         while True:


### PR DESCRIPTION
Previously directories were reused when cloning repos, and configured based on github urls (organization/repo).  This fix may solve a file lock issue that has cropped up, and is needed to clone from git repos hosted outside of github.  Instead of a timestamp, a registration ID is generated for each registration.

This also adds an admin method to remove modules that have not been released, and bumps the version to 0.0.6.