### PR TITLE
Added proper storage of logs

### DIFF
--- a/catalog.spec
+++ b/catalog.spec
@@ -94,6 +94,7 @@ module Catalog {
 
     typedef structure {
         int timestamp;
+        string registration_id;
         string version;
         string git_commit_hash;
         string git_commit_message;
@@ -167,7 +168,6 @@ module Catalog {
         string release_approval;
         string review_message;
         string registration;
-        string last_registration_id;
         string error_message;
     } ModuleState;
 
@@ -175,10 +175,13 @@ module Catalog {
     funcdef get_module_state(SelectOneModuleParams params) returns (ModuleState state);
 
 
+    /* must specify skip & limit, or first_n, or last_n.  If none given, this gets last 5000 lines */
     typedef structure {
         string registration_id;
-        int line_start;
-        int line_end;
+        int skip;
+        int limit;
+        int first_n;
+        int last_n;
     } GetBuildLogParams;
 
     typedef structure {
@@ -186,17 +189,23 @@ module Catalog {
         boolean error;
     } BuildLogLine;
 
+    
     typedef structure {
+        string registration_id;
+        string timestamp;
+        string module_name_lc;
+        string git_url;
+        string error;
+        string registration;
         list <BuildLogLine> log;
     } BuildLog;
-
 
     funcdef get_build_log(string registration_id) returns (string);
 
     /*
         given the registration_id returned from the register method, you can check the build log with this method
     */
-    funcdef get_build_log2(GetBuildLogParams params) returns (BuildLog build_log);
+    funcdef get_parsed_build_log(GetBuildLogParams params) returns (BuildLog build_log);
 
 
     typedef structure {

--- a/catalog.spec
+++ b/catalog.spec
@@ -189,7 +189,7 @@ module Catalog {
         boolean error;
     } BuildLogLine;
 
-    
+
     typedef structure {
         string registration_id;
         string timestamp;
@@ -212,17 +212,21 @@ module Catalog {
         string registration_id;
         string registration;
         string error_message;
-        string module_name;
+        string module_name_lc;
         string git_url;
     } BuildInfo;
 
     /*
-
         Always sorted by time, oldest builds are last.
 
-        only_running - if true, only show running builds
-        only_error - if true, only show builds that ended in an error
+        only one of these can be set to true:
+            only_running - if true, only show running builds
+            only_error - if true, only show builds that ended in an error
+            only_complete - if true, only show builds that are complete
+        skip - skip these first n records, default 0
+        limit - limit result to the most recent n records, default 1000
 
+        modules - only include builds from these modules based on names/git_urls
     */
     typedef structure {
         boolean only_runnning;

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -26,7 +26,7 @@ Bio::KBase::Catalog::Client
 =head1 DESCRIPTION
 
 
-Service for managing, registering, and building KBase Modules.
+Service for managing, registering, and building KBase Modules using the KBase SDK.
 
 
 =cut
@@ -205,7 +205,7 @@ boolean is an int
 
 =item Description
 
-
+returns true (1) if the module exists, false (2) otherwise
 
 =back
 
@@ -1230,6 +1230,7 @@ ModuleState is a reference to a hash where the following keys are defined:
 	release_approval has a value which is a string
 	review_message has a value which is a string
 	registration has a value which is a string
+	last_registration_id has a value which is a string
 	error_message has a value which is a string
 boolean is an int
 
@@ -1250,6 +1251,7 @@ ModuleState is a reference to a hash where the following keys are defined:
 	release_approval has a value which is a string
 	review_message has a value which is a string
 	registration has a value which is a string
+	last_registration_id has a value which is a string
 	error_message has a value which is a string
 boolean is an int
 
@@ -1339,7 +1341,7 @@ $return is a string
 
 =item Description
 
-given the registration_id returned from the register method, you can check the build log with this method
+
 
 =back
 
@@ -1386,6 +1388,222 @@ given the registration_id returned from the register method, you can check the b
         Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_build_log",
 					    status_line => $self->{client}->status_line,
 					    method_name => 'get_build_log',
+				       );
+    }
+}
+ 
+
+
+=head2 get_build_log2
+
+  $build_log = $obj->get_build_log2($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a Catalog.GetBuildLogParams
+$build_log is a Catalog.BuildLog
+GetBuildLogParams is a reference to a hash where the following keys are defined:
+	registration_id has a value which is a string
+	line_start has a value which is an int
+	line_end has a value which is an int
+BuildLog is a reference to a hash where the following keys are defined:
+	log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
+BuildLogLine is a reference to a hash where the following keys are defined:
+	content has a value which is a string
+	error has a value which is a Catalog.boolean
+boolean is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a Catalog.GetBuildLogParams
+$build_log is a Catalog.BuildLog
+GetBuildLogParams is a reference to a hash where the following keys are defined:
+	registration_id has a value which is a string
+	line_start has a value which is an int
+	line_end has a value which is an int
+BuildLog is a reference to a hash where the following keys are defined:
+	log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
+BuildLogLine is a reference to a hash where the following keys are defined:
+	content has a value which is a string
+	error has a value which is a Catalog.boolean
+boolean is an int
+
+
+=end text
+
+=item Description
+
+given the registration_id returned from the register method, you can check the build log with this method
+
+=back
+
+=cut
+
+ sub get_build_log2
+{
+    my($self, @args) = @_;
+
+# Authentication: none
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function get_build_log2 (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to get_build_log2:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'get_build_log2');
+	}
+    }
+
+    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
+	method => "Catalog.get_build_log2",
+	params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'get_build_log2',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_build_log2",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'get_build_log2',
+				       );
+    }
+}
+ 
+
+
+=head2 list_builds
+
+  $builds = $obj->list_builds($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a Catalog.ListBuildParams
+$builds is a reference to a list where each element is a Catalog.BuildInfo
+ListBuildParams is a reference to a hash where the following keys are defined:
+	only_runnning has a value which is a Catalog.boolean
+	only_error has a value which is a Catalog.boolean
+	only_complete has a value which is a Catalog.boolean
+	skip has a value which is an int
+	limit has a value which is an int
+	modules has a value which is a reference to a list where each element is a Catalog.SelectOneModuleParams
+boolean is an int
+SelectOneModuleParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	git_url has a value which is a string
+BuildInfo is a reference to a hash where the following keys are defined:
+	registration_id has a value which is a string
+	registration has a value which is a string
+	error_message has a value which is a string
+	module_name has a value which is a string
+	git_url has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a Catalog.ListBuildParams
+$builds is a reference to a list where each element is a Catalog.BuildInfo
+ListBuildParams is a reference to a hash where the following keys are defined:
+	only_runnning has a value which is a Catalog.boolean
+	only_error has a value which is a Catalog.boolean
+	only_complete has a value which is a Catalog.boolean
+	skip has a value which is an int
+	limit has a value which is an int
+	modules has a value which is a reference to a list where each element is a Catalog.SelectOneModuleParams
+boolean is an int
+SelectOneModuleParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	git_url has a value which is a string
+BuildInfo is a reference to a hash where the following keys are defined:
+	registration_id has a value which is a string
+	registration has a value which is a string
+	error_message has a value which is a string
+	module_name has a value which is a string
+	git_url has a value which is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub list_builds
+{
+    my($self, @args) = @_;
+
+# Authentication: none
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function list_builds (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to list_builds:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'list_builds');
+	}
+    }
+
+    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
+	method => "Catalog.list_builds",
+	params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'list_builds',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method list_builds",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'list_builds',
 				       );
     }
 }
@@ -2142,7 +2360,7 @@ an int
 
 =item Description
 
-Describes how to find module/repository.
+Describes how to find a single module/repository.
 module_name - name of module defined in kbase.yaml file;
 git_url - the url used to register the module
 
@@ -2548,7 +2766,7 @@ error_message has a value which is a string
 active: True | False,
 release_approval: approved | denied | under_review | not_requested, (all releases require approval)
 review_message: str, (optional)
-registration: building | complete | error,
+registration: complete | error | (build state status),
 error_message: str (optional)
 
 
@@ -2563,6 +2781,7 @@ released has a value which is a Catalog.boolean
 release_approval has a value which is a string
 review_message has a value which is a string
 registration has a value which is a string
+last_registration_id has a value which is a string
 error_message has a value which is a string
 
 </pre>
@@ -2577,7 +2796,190 @@ released has a value which is a Catalog.boolean
 release_approval has a value which is a string
 review_message has a value which is a string
 registration has a value which is a string
+last_registration_id has a value which is a string
 error_message has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 GetBuildLogParams
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+registration_id has a value which is a string
+line_start has a value which is an int
+line_end has a value which is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+registration_id has a value which is a string
+line_start has a value which is an int
+line_end has a value which is an int
+
+
+=end text
+
+=back
+
+
+
+=head2 BuildLogLine
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+content has a value which is a string
+error has a value which is a Catalog.boolean
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+content has a value which is a string
+error has a value which is a Catalog.boolean
+
+
+=end text
+
+=back
+
+
+
+=head2 BuildLog
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
+
+
+=end text
+
+=back
+
+
+
+=head2 BuildInfo
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+registration_id has a value which is a string
+registration has a value which is a string
+error_message has a value which is a string
+module_name has a value which is a string
+git_url has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+registration_id has a value which is a string
+registration has a value which is a string
+error_message has a value which is a string
+module_name has a value which is a string
+git_url has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 ListBuildParams
+
+=over 4
+
+
+
+=item Description
+
+Always sorted by time, oldest builds are last.
+
+        only_running - if true, only show running builds
+        only_error - if true, only show builds that ended in an error
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+only_runnning has a value which is a Catalog.boolean
+only_error has a value which is a Catalog.boolean
+only_complete has a value which is a Catalog.boolean
+skip has a value which is an int
+limit has a value which is an int
+modules has a value which is a reference to a list where each element is a Catalog.SelectOneModuleParams
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+only_runnning has a value which is a Catalog.boolean
+only_error has a value which is a Catalog.boolean
+only_complete has a value which is a Catalog.boolean
+skip has a value which is an int
+limit has a value which is an int
+modules has a value which is a reference to a list where each element is a Catalog.SelectOneModuleParams
 
 
 =end text

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -1543,7 +1543,7 @@ BuildInfo is a reference to a hash where the following keys are defined:
 	registration_id has a value which is a string
 	registration has a value which is a string
 	error_message has a value which is a string
-	module_name has a value which is a string
+	module_name_lc has a value which is a string
 	git_url has a value which is a string
 
 </pre>
@@ -1569,7 +1569,7 @@ BuildInfo is a reference to a hash where the following keys are defined:
 	registration_id has a value which is a string
 	registration has a value which is a string
 	error_message has a value which is a string
-	module_name has a value which is a string
+	module_name_lc has a value which is a string
 	git_url has a value which is a string
 
 
@@ -2958,7 +2958,7 @@ a reference to a hash where the following keys are defined:
 registration_id has a value which is a string
 registration has a value which is a string
 error_message has a value which is a string
-module_name has a value which is a string
+module_name_lc has a value which is a string
 git_url has a value which is a string
 
 </pre>
@@ -2971,7 +2971,7 @@ a reference to a hash where the following keys are defined:
 registration_id has a value which is a string
 registration has a value which is a string
 error_message has a value which is a string
-module_name has a value which is a string
+module_name_lc has a value which is a string
 git_url has a value which is a string
 
 
@@ -2991,8 +2991,14 @@ git_url has a value which is a string
 
 Always sorted by time, oldest builds are last.
 
-        only_running - if true, only show running builds
-        only_error - if true, only show builds that ended in an error
+only one of these can be set to true:
+    only_running - if true, only show running builds
+    only_error - if true, only show builds that ended in an error
+    only_complete - if true, only show builds that are complete
+skip - skip these first n records, default 0
+limit - limit result to the most recent n records, default 1000
+
+modules - only include builds from these modules based on names/git_urls
 
 
 =item Definition

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -819,6 +819,7 @@ ModuleInfo is a reference to a hash where the following keys are defined:
 	dev has a value which is a Catalog.ModuleVersionInfo
 ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	timestamp has a value which is an int
+	registration_id has a value which is a string
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
@@ -847,6 +848,7 @@ ModuleInfo is a reference to a hash where the following keys are defined:
 	dev has a value which is a Catalog.ModuleVersionInfo
 ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	timestamp has a value which is an int
+	registration_id has a value which is a string
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
@@ -932,6 +934,7 @@ SelectModuleVersionParams is a reference to a hash where the following keys are 
 	version has a value which is a string
 ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	timestamp has a value which is an int
+	registration_id has a value which is a string
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
@@ -954,6 +957,7 @@ SelectModuleVersionParams is a reference to a hash where the following keys are 
 	version has a value which is a string
 ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	timestamp has a value which is an int
+	registration_id has a value which is a string
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
@@ -1036,6 +1040,7 @@ SelectOneModuleParams is a reference to a hash where the following keys are defi
 	git_url has a value which is a string
 ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	timestamp has a value which is an int
+	registration_id has a value which is a string
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
@@ -1055,6 +1060,7 @@ SelectOneModuleParams is a reference to a hash where the following keys are defi
 	git_url has a value which is a string
 ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	timestamp has a value which is an int
+	registration_id has a value which is a string
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
@@ -1230,7 +1236,6 @@ ModuleState is a reference to a hash where the following keys are defined:
 	release_approval has a value which is a string
 	review_message has a value which is a string
 	registration has a value which is a string
-	last_registration_id has a value which is a string
 	error_message has a value which is a string
 boolean is an int
 
@@ -1251,7 +1256,6 @@ ModuleState is a reference to a hash where the following keys are defined:
 	release_approval has a value which is a string
 	review_message has a value which is a string
 	registration has a value which is a string
-	last_registration_id has a value which is a string
 	error_message has a value which is a string
 boolean is an int
 
@@ -1394,9 +1398,9 @@ $return is a string
  
 
 
-=head2 get_build_log2
+=head2 get_parsed_build_log
 
-  $build_log = $obj->get_build_log2($params)
+  $build_log = $obj->get_parsed_build_log($params)
 
 =over 4
 
@@ -1409,9 +1413,17 @@ $params is a Catalog.GetBuildLogParams
 $build_log is a Catalog.BuildLog
 GetBuildLogParams is a reference to a hash where the following keys are defined:
 	registration_id has a value which is a string
-	line_start has a value which is an int
-	line_end has a value which is an int
+	skip has a value which is an int
+	limit has a value which is an int
+	first_n has a value which is an int
+	last_n has a value which is an int
 BuildLog is a reference to a hash where the following keys are defined:
+	registration_id has a value which is a string
+	timestamp has a value which is a string
+	module_name_lc has a value which is a string
+	git_url has a value which is a string
+	error has a value which is a string
+	registration has a value which is a string
 	log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
 BuildLogLine is a reference to a hash where the following keys are defined:
 	content has a value which is a string
@@ -1428,9 +1440,17 @@ $params is a Catalog.GetBuildLogParams
 $build_log is a Catalog.BuildLog
 GetBuildLogParams is a reference to a hash where the following keys are defined:
 	registration_id has a value which is a string
-	line_start has a value which is an int
-	line_end has a value which is an int
+	skip has a value which is an int
+	limit has a value which is an int
+	first_n has a value which is an int
+	last_n has a value which is an int
 BuildLog is a reference to a hash where the following keys are defined:
+	registration_id has a value which is a string
+	timestamp has a value which is a string
+	module_name_lc has a value which is a string
+	git_url has a value which is a string
+	error has a value which is a string
+	registration has a value which is a string
 	log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
 BuildLogLine is a reference to a hash where the following keys are defined:
 	content has a value which is a string
@@ -1448,7 +1468,7 @@ given the registration_id returned from the register method, you can check the b
 
 =cut
 
- sub get_build_log2
+ sub get_parsed_build_log
 {
     my($self, @args) = @_;
 
@@ -1457,7 +1477,7 @@ given the registration_id returned from the register method, you can check the b
     if ((my $n = @args) != 1)
     {
 	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-							       "Invalid argument count for function get_build_log2 (received $n, expecting 1)");
+							       "Invalid argument count for function get_parsed_build_log (received $n, expecting 1)");
     }
     {
 	my($params) = @args;
@@ -1465,30 +1485,30 @@ given the registration_id returned from the register method, you can check the b
 	my @_bad_arguments;
         (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
         if (@_bad_arguments) {
-	    my $msg = "Invalid arguments passed to get_build_log2:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    my $msg = "Invalid arguments passed to get_parsed_build_log:\n" . join("", map { "\t$_\n" } @_bad_arguments);
 	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-								   method_name => 'get_build_log2');
+								   method_name => 'get_parsed_build_log');
 	}
     }
 
     my $result = $self->{client}->call($self->{url}, $self->{headers}, {
-	method => "Catalog.get_build_log2",
+	method => "Catalog.get_parsed_build_log",
 	params => \@args,
     });
     if ($result) {
 	if ($result->is_error) {
 	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
 					       code => $result->content->{error}->{code},
-					       method_name => 'get_build_log2',
+					       method_name => 'get_parsed_build_log',
 					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
 					      );
 	} else {
 	    return wantarray ? @{$result->result} : $result->result->[0];
 	}
     } else {
-        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_build_log2",
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_parsed_build_log",
 					    status_line => $self->{client}->status_line,
-					    method_name => 'get_build_log2',
+					    method_name => 'get_parsed_build_log',
 				       );
     }
 }
@@ -2594,6 +2614,7 @@ git_url has a value which is a string
 <pre>
 a reference to a hash where the following keys are defined:
 timestamp has a value which is an int
+registration_id has a value which is a string
 version has a value which is a string
 git_commit_hash has a value which is a string
 git_commit_message has a value which is a string
@@ -2608,6 +2629,7 @@ docker_img_name has a value which is a string
 
 a reference to a hash where the following keys are defined:
 timestamp has a value which is an int
+registration_id has a value which is a string
 version has a value which is a string
 git_commit_hash has a value which is a string
 git_commit_message has a value which is a string
@@ -2781,7 +2803,6 @@ released has a value which is a Catalog.boolean
 release_approval has a value which is a string
 review_message has a value which is a string
 registration has a value which is a string
-last_registration_id has a value which is a string
 error_message has a value which is a string
 
 </pre>
@@ -2796,7 +2817,6 @@ released has a value which is a Catalog.boolean
 release_approval has a value which is a string
 review_message has a value which is a string
 registration has a value which is a string
-last_registration_id has a value which is a string
 error_message has a value which is a string
 
 
@@ -2812,6 +2832,11 @@ error_message has a value which is a string
 
 
 
+=item Description
+
+must specify skip & limit, or first_n, or last_n.  If none given, this gets last 5000 lines
+
+
 =item Definition
 
 =begin html
@@ -2819,8 +2844,10 @@ error_message has a value which is a string
 <pre>
 a reference to a hash where the following keys are defined:
 registration_id has a value which is a string
-line_start has a value which is an int
-line_end has a value which is an int
+skip has a value which is an int
+limit has a value which is an int
+first_n has a value which is an int
+last_n has a value which is an int
 
 </pre>
 
@@ -2830,8 +2857,10 @@ line_end has a value which is an int
 
 a reference to a hash where the following keys are defined:
 registration_id has a value which is a string
-line_start has a value which is an int
-line_end has a value which is an int
+skip has a value which is an int
+limit has a value which is an int
+first_n has a value which is an int
+last_n has a value which is an int
 
 
 =end text
@@ -2884,6 +2913,12 @@ error has a value which is a Catalog.boolean
 
 <pre>
 a reference to a hash where the following keys are defined:
+registration_id has a value which is a string
+timestamp has a value which is a string
+module_name_lc has a value which is a string
+git_url has a value which is a string
+error has a value which is a string
+registration has a value which is a string
 log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
 
 </pre>
@@ -2893,6 +2928,12 @@ log has a value which is a reference to a list where each element is a Catalog.B
 =begin text
 
 a reference to a hash where the following keys are defined:
+registration_id has a value which is a string
+timestamp has a value which is a string
+module_name_lc has a value which is a string
+git_url has a value which is a string
+error has a value which is a string
+registration has a value which is a string
 log has a value which is a reference to a list where each element is a Catalog.BuildLogLine
 
 

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -265,10 +265,10 @@ class Catalog(object):
                           [registration_id], json_rpc_context)
         return resp[0]
   
-    def get_build_log2(self, params, json_rpc_context = None):
+    def get_parsed_build_log(self, params, json_rpc_context = None):
         if json_rpc_context and type(json_rpc_context) is not dict:
-            raise ValueError('Method get_build_log2: argument json_rpc_context is not type dict as required.')
-        resp = self._call('Catalog.get_build_log2',
+            raise ValueError('Method get_parsed_build_log: argument json_rpc_context is not type dict as required.')
+        resp = self._call('Catalog.get_parsed_build_log',
                           [params], json_rpc_context)
         return resp[0]
   

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -265,6 +265,20 @@ class Catalog(object):
                           [registration_id], json_rpc_context)
         return resp[0]
   
+    def get_build_log2(self, params, json_rpc_context = None):
+        if json_rpc_context and type(json_rpc_context) is not dict:
+            raise ValueError('Method get_build_log2: argument json_rpc_context is not type dict as required.')
+        resp = self._call('Catalog.get_build_log2',
+                          [params], json_rpc_context)
+        return resp[0]
+  
+    def list_builds(self, params, json_rpc_context = None):
+        if json_rpc_context and type(json_rpc_context) is not dict:
+            raise ValueError('Method list_builds: argument json_rpc_context is not type dict as required.')
+        resp = self._call('Catalog.list_builds',
+                          [params], json_rpc_context)
+        return resp[0]
+  
     def delete_module(self, params, json_rpc_context = None):
         if json_rpc_context and type(json_rpc_context) is not dict:
             raise ValueError('Method delete_module: argument json_rpc_context is not type dict as required.')

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -241,6 +241,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: builds
         #BEGIN list_builds
+        builds = self.cc.list_builds(params)
         #END list_builds
 
         # At some point might do deeper type checking...

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -10,7 +10,7 @@ class Catalog:
     Catalog
 
     Module Description:
-    Service for managing, registering, and building KBase Modules.
+    Service for managing, registering, and building KBase Modules using the KBase SDK.
     '''
 
     ######## WARNING FOR GEVENT USERS #######
@@ -222,6 +222,32 @@ class Catalog:
                              'returnVal is not type basestring as required.')
         # return the results
         return [returnVal]
+
+    def get_build_log2(self, ctx, params):
+        # ctx is the context object
+        # return variables are: build_log
+        #BEGIN get_build_log2
+        #END get_build_log2
+
+        # At some point might do deeper type checking...
+        if not isinstance(build_log, dict):
+            raise ValueError('Method get_build_log2 return value ' +
+                             'build_log is not type dict as required.')
+        # return the results
+        return [build_log]
+
+    def list_builds(self, ctx, params):
+        # ctx is the context object
+        # return variables are: builds
+        #BEGIN list_builds
+        #END list_builds
+
+        # At some point might do deeper type checking...
+        if not isinstance(builds, list):
+            raise ValueError('Method list_builds return value ' +
+                             'builds is not type list as required.')
+        # return the results
+        return [builds]
 
     def delete_module(self, ctx, params):
         # ctx is the context object

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -223,15 +223,16 @@ class Catalog:
         # return the results
         return [returnVal]
 
-    def get_build_log2(self, ctx, params):
+    def get_parsed_build_log(self, ctx, params):
         # ctx is the context object
         # return variables are: build_log
-        #BEGIN get_build_log2
-        #END get_build_log2
+        #BEGIN get_parsed_build_log
+        build_log = self.cc.get_parsed_build_log(params)
+        #END get_parsed_build_log
 
         # At some point might do deeper type checking...
         if not isinstance(build_log, dict):
-            raise ValueError('Method get_build_log2 return value ' +
+            raise ValueError('Method get_parsed_build_log return value ' +
                              'build_log is not type dict as required.')
         # return the results
         return [build_log]

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -102,9 +102,9 @@ sync_methods['Catalog.get_module_state'] = True
 async_run_methods['Catalog.get_build_log_async'] = ['Catalog', 'get_build_log']
 async_check_methods['Catalog.get_build_log_check'] = ['Catalog', 'get_build_log']
 sync_methods['Catalog.get_build_log'] = True
-async_run_methods['Catalog.get_build_log2_async'] = ['Catalog', 'get_build_log2']
-async_check_methods['Catalog.get_build_log2_check'] = ['Catalog', 'get_build_log2']
-sync_methods['Catalog.get_build_log2'] = True
+async_run_methods['Catalog.get_parsed_build_log_async'] = ['Catalog', 'get_parsed_build_log']
+async_check_methods['Catalog.get_parsed_build_log_check'] = ['Catalog', 'get_parsed_build_log']
+sync_methods['Catalog.get_parsed_build_log'] = True
 async_run_methods['Catalog.list_builds_async'] = ['Catalog', 'list_builds']
 async_check_methods['Catalog.list_builds_check'] = ['Catalog', 'list_builds']
 sync_methods['Catalog.list_builds'] = True
@@ -459,10 +459,10 @@ class Application(object):
                              name='Catalog.get_build_log',
                              types=[basestring])
         self.method_authentication['Catalog.get_build_log'] = 'none'
-        self.rpc_service.add(impl_Catalog.get_build_log2,
-                             name='Catalog.get_build_log2',
+        self.rpc_service.add(impl_Catalog.get_parsed_build_log,
+                             name='Catalog.get_parsed_build_log',
                              types=[dict])
-        self.method_authentication['Catalog.get_build_log2'] = 'none'
+        self.method_authentication['Catalog.get_parsed_build_log'] = 'none'
         self.rpc_service.add(impl_Catalog.list_builds,
                              name='Catalog.list_builds',
                              types=[dict])

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -102,6 +102,12 @@ sync_methods['Catalog.get_module_state'] = True
 async_run_methods['Catalog.get_build_log_async'] = ['Catalog', 'get_build_log']
 async_check_methods['Catalog.get_build_log_check'] = ['Catalog', 'get_build_log']
 sync_methods['Catalog.get_build_log'] = True
+async_run_methods['Catalog.get_build_log2_async'] = ['Catalog', 'get_build_log2']
+async_check_methods['Catalog.get_build_log2_check'] = ['Catalog', 'get_build_log2']
+sync_methods['Catalog.get_build_log2'] = True
+async_run_methods['Catalog.list_builds_async'] = ['Catalog', 'list_builds']
+async_check_methods['Catalog.list_builds_check'] = ['Catalog', 'list_builds']
+sync_methods['Catalog.list_builds'] = True
 async_run_methods['Catalog.delete_module_async'] = ['Catalog', 'delete_module']
 async_check_methods['Catalog.delete_module_check'] = ['Catalog', 'delete_module']
 sync_methods['Catalog.delete_module'] = True
@@ -323,6 +329,7 @@ class MethodContext(dict):
         self['method'] = None
         self['call_id'] = None
         self['rpc_context'] = None
+        self['provenance'] = None
         self._debug_levels = set([7, 8, 9, 'DEBUG', 'DEBUG2', 'DEBUG3'])
         self._logger = logger
 
@@ -452,6 +459,14 @@ class Application(object):
                              name='Catalog.get_build_log',
                              types=[basestring])
         self.method_authentication['Catalog.get_build_log'] = 'none'
+        self.rpc_service.add(impl_Catalog.get_build_log2,
+                             name='Catalog.get_build_log2',
+                             types=[dict])
+        self.method_authentication['Catalog.get_build_log2'] = 'none'
+        self.rpc_service.add(impl_Catalog.list_builds,
+                             name='Catalog.list_builds',
+                             types=[dict])
+        self.method_authentication['Catalog.list_builds'] = 'none'
         self.rpc_service.add(impl_Catalog.delete_module,
                              name='Catalog.delete_module',
                              types=[dict])
@@ -519,6 +534,9 @@ class Application(object):
                 ctx['module'], ctx['method'] = req['method'].split('.')
                 ctx['call_id'] = req['id']
                 ctx['rpc_context'] = {'call_stack': [{'time':self.now_in_utc(), 'method': req['method']}]}
+                prov_action = {'service': ctx['module'], 'method': ctx['method'], 
+                               'method_params': req['params']}
+                ctx['provenance'] = [prov_action]
                 try:
                     token = environ.get('HTTP_AUTHORIZATION')
                     # parse out the method being requested and check if it
@@ -742,6 +760,10 @@ def process_async_cli(input_file_path, output_file_path, token):
     if 'context' in req:
         ctx['rpc_context'] = req['context']
     ctx['CLI'] = 1
+    ctx['module'], ctx['method'] = req['method'].split('.')
+    prov_action = {'service': ctx['module'], 'method': ctx['method'], 
+                   'method_params': req['params']}
+    ctx['provenance'] = [prov_action]
     resp = None
     try:
         resp = application.rpc_service.call_py(ctx, req)

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -499,7 +499,7 @@ class CatalogController:
             simple_kbase_dev_list.append(d['kb_username'])
         return sorted(simple_kbase_dev_list)
 
-
+    # get the build log from file that it is being written to
     def get_build_log(self, registration_id):
         try:
             with open(self.temp_dir+'/registration.log.'+str(registration_id)) as log_file:
@@ -507,6 +507,29 @@ class CatalogController:
         except:
             log = '[log not found - registration_id is invalid or the log has been deleted]'
         return log
+
+    # get the parsed build log from mongo
+    def get_parsed_build_log(self, params):
+        if 'registration_id' not in params:
+            raise ValueError('You must specify a registration_id to retrieve a build log')
+
+        slice_arg = None
+        if 'skip' in params:
+            if 'limit' not in params:
+                raise ValueError('Cannot specify the skip argument without a limit- blame Mongo')    
+            slice_arg = [int(params['skip']),int(params['limit'])]
+
+        if 'first_n' in params:
+            if slice_arg is not None:
+                raise ValueError('Cannot combine skip/limit with first_n parameters')
+            slice_arg = int(params['first_n'])
+
+        if 'last_n' in params:
+            if slice_arg is not None:
+                raise ValueError('Cannot combine skip/limit/first_n with last_n parameters')
+            slice_arg = -int(params['last_n'])
+
+        return self.db.get_parsed_build_log(params['registration_id'], slice_arg = slice_arg)
 
 
     def delete_module(self,params,username):

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -177,18 +177,18 @@ class CatalogController:
         if params['registration_state'] == 'error':
             if 'error_message' not in params:
                 raise ValueError('Update failed - if state is "error", you must also set an "error_message".')
-            if params['error_message']:
+            if not params['error_message']:
                 raise ValueError('Update failed - if state is "error", you must also set an "error_message".')
             error_message = params['error_message']
-        else:
-            # then we update the state
-            error = self.db.set_module_registration_state(
-                        git_url=params['git_url'],
-                        module_name=params['module_name'],
-                        new_state=params['registration_state'],
-                        error_message=error_message)
-            if error is not None:
-                raise ValueError('Registration failed for git repo ('+git_url+')- some unknown database error: ' + error)
+        
+        # then we update the state
+        error = self.db.set_module_registration_state(
+                    git_url=params['git_url'],
+                    module_name=params['module_name'],
+                    new_state=params['registration_state'],
+                    error_message=error_message)
+        if error is not None:
+            raise ValueError('Registration failed for git repo ('+git_url+')- some unknown database error: ' + error)
 
 
     def push_dev_to_beta(self, params, username):

--- a/lib/biokbase/catalog/db.py
+++ b/lib/biokbase/catalog/db.py
@@ -64,6 +64,10 @@ Module Document:
         }
     }
 
+
+
+
+
 '''
 class MongoCatalogDBI:
 
@@ -71,6 +75,7 @@ class MongoCatalogDBI:
 
     _MODULES='modules'
     _DEVELOPERS='developers'
+    _BUILD_LOGS='build_logs'
 
     def __init__(self, mongo_host, mongo_db, mongo_user, mongo_psswd):
 
@@ -85,6 +90,7 @@ class MongoCatalogDBI:
         self.db = self.mongo[mongo_db]
         self.modules = self.db[MongoCatalogDBI._MODULES]
         self.developers = self.db[MongoCatalogDBI._DEVELOPERS]
+        self.build_logs = self.db[MongoCatalogDBI._BUILD_LOGS]
 
         # Make sure we have an index on module and git_repo_url
         self.modules.ensure_index('module_name', unique=True, sparse=True)
@@ -95,6 +101,10 @@ class MongoCatalogDBI:
         self.modules.ensure_index('owners.kb_username')
 
         self.developers.ensure_index('kb_username', unique=True)
+
+        self.build_logs.ensure_index('registration_id',unique=True)
+        self.build_logs.ensure_index('module_name_lc')
+        self.build_logs.ensure_index('git_url')
 
 
 
@@ -117,6 +127,25 @@ class MongoCatalogDBI:
 
 
     #### SET methods
+    def save_new_build_log(self, registration_id, module_name_lc, git_url, log):
+        build_log = {
+            'registration_id':registration_id,
+            'module_name_lc' : module_name_lc,
+            'git_url':git_url,
+            'log':log
+        }
+        self.build_logs.insert(module)
+
+    def update_build_log(self,registration_id, log):
+        result = self.build_logs.update({'registration_id':registration_id}, 
+            { '$set':{'log':log} })
+        return self._check_update_result(result)
+
+    def list_build_logs(self,module_name_lc='',git_url=''):
+        pass
+
+    def get_build_log(self,registration_id):
+        pass
 
     def register_new_module(self, git_url, username, timestamp):
         # get current time since epoch in ms in utc

--- a/lib/biokbase/catalog/db.py
+++ b/lib/biokbase/catalog/db.py
@@ -171,9 +171,22 @@ class MongoCatalogDBI:
     def list_build_logs(self,module_name_lc='',git_url=''):
         pass
 
-    def get_build_log(self,registration_id):
-        return self.build_logs.find({'registration_id':registration_id},{'module_name':1,'git_url':1,'current_versions':1,'owners':1,'_id':0})
+    # slice arg is used in the mongo query for getting lines.  It is either a
+    # pos int (get first n lines), neg int (last n lines), or array [skip, limit]
+    def get_parsed_build_log(self,registration_id, slice_arg=None):
+        selection = {
+                        'registration_id':1,
+                        'timestamp':1,
+                        'git_url':1,
+                        'module_name_lc':1,
+                        'registration':1,
+                        'error_message':1,
+                        'log':1
+                    }
+        if slice_arg:
+            selection['log'] = {'$slice':slice_arg}
 
+        return self.build_logs.find_one({'registration_id':registration_id},selection)
 
 
     def register_new_module(self, git_url, username, timestamp, registration_state, registration_id):
@@ -186,7 +199,6 @@ class MongoCatalogDBI:
                 'active': True,
                 'released': False,
                 'release_approval': 'not_requested',
-                'registration_id' : registration_id,
                 'registration': registration_state,
                 'error_message' : '',
             },

--- a/lib/biokbase/catalog/registrar.py
+++ b/lib/biokbase/catalog/registrar.py
@@ -47,6 +47,11 @@ class Registrar:
         # (most) of the mongo document for this module snapshot before this registration
         self.module_details = module_details
 
+        self.log_buffer = [];
+        self.last_log_time = time.time() # in seconds
+        self.log_interval = 1.0 # save log to mongo every second
+
+
     def start_registration(self):
         try:
             self.logfile = open(self.temp_dir+'/registration.log.'+self.registration_id, 'w')
@@ -84,18 +89,21 @@ class Registrar:
             self.sanity_checks_and_parse(repo, basedir)
 
             ##############################
-            # 2.5 - waiting for one minute at most until git releases .git/config.lock
+            # 2.5 - waiting for one minute at most until git releases .git/config.lock, if it still exists then kill it
             timeout = time.time() + 60
             git_config_lock_file = os.path.join(basedir, ".git", "config.lock")
             while os.path.exists(git_config_lock_file) and time.time() <= timeout:
-                self.log('Trying to remove .git/config.lock file release...')
-                os.remove(git_config_lock_file)
+                self.log('.git/config.lock exists, waiting 5s for it to release')
                 time.sleep(5)
+            if os.path.exists(git_config_lock_file):
+                self.log('.git/config.lock file still there, we are just going to delete it....')
+                os.remove(git_config_lock_file)
 
             ##############################
             # 3 docker build - in progress
             # perhaps make this a self attr?
             module_name_lc = self.get_required_field_as_string(self.kb_yaml,'module-name').strip().lower()
+            self.db.set_build_log_module_name(self.registration_id, module_name_lc)
             self.image_name = self.docker_registry_host + '/' + module_name_lc + ':' + str(git_commit_hash)
             if not Registrar._TEST_WITHOUT_DOCKER:
                 # timeout set to 30 min because we often get timeouts if multiple people try to push at the same time
@@ -148,9 +156,10 @@ class Registrar:
         except Exception as e:
             # set the build state to error and log it
             self.set_build_error(str(e))
-            self.log(traceback.format_exc())
-            self.log('BUILD_ERROR: '+str(e))
+            self.log(traceback.format_exc(), is_error=True)
+            self.log('BUILD_ERROR: '+str(e), is_error=True)
         finally:
+            self.flush_log_to_db();
             self.logfile.close();
             self.cleanup();
 
@@ -318,13 +327,13 @@ class Registrar:
                                 for w in result['warnings']:
                                     self.log('        - warning: '+w)
                     else:
-                        self.log('        - not valid!')
+                        self.log('        - not valid!', is_error=True)
                         if 'errors' in result:
                             if result['errors']:
                                 for e in result['errors']:
-                                    self.log('        - error: '+e)
+                                    self.log('        - error: '+e, is_error=True)
                         else:
-                            self.log('        - error is undefined!'+e)
+                            self.log('        - error is undefined!'+e,  is_error=True)
 
                         raise ValueError('Invalid narrative method specification ('+m+')')
 
@@ -353,21 +362,41 @@ class Registrar:
         return value
 
 
-    def log(self, message, no_end_line=False):
+    def log(self, message, no_end_line=False, is_error=False):
         if no_end_line:
-            self.logfile.write(message)
+            content = message
         else:
-            self.logfile.write(message+'\n')
+            content = message + '\n'
+        self.logfile.write(content)
         self.logfile.flush()
+
+        lines = content.splitlines();
+        for l in lines:
+            # add each line to the buffer
+            self.log_buffer.append({'content':l, 'error':is_error})
+
+        # save the buffer to mongo if enough time has elapsed, or the buffer is more than 1000 lines
+        if (time.time() - self.last_log_time > self.log_interval) or (len(self.log_buffer)>1000):
+            self.flush_log_to_db();
+
+    def flush_log_to_db(self):
+        # todo: if we lose log lines, that's ok.  Make sure we handle case if log is larger than mongo doc size
+        self.db.append_to_build_log(self.registration_id, self.log_buffer)
+        self.log_buffer = [] #clear the buffer
+        self.last_log_time = time.time() # reset the log timer
+
 
     def set_build_step(self, step):
         self.db.set_module_registration_state(git_url=self.git_url, new_state='building: '+step)
+        self.db.set_build_log_state(self.registration_id, 'building: '+step)
 
     def set_build_error(self, error_message):
         self.db.set_module_registration_state(git_url=self.git_url, new_state='error', error_message=error_message)
+        self.db.set_build_log_state(self.registration_id, 'error', error_message=error_message)
 
     def build_is_complete(self):
         self.db.set_module_registration_state(git_url=self.git_url, new_state='complete')
+        self.db.set_build_log_state(self.registration_id, 'complete')
 
     def cleanup(self):
         if os.path.isdir(os.path.join(self.temp_dir,self.registration_id)):

--- a/lib/biokbase/catalog/version.py
+++ b/lib/biokbase/catalog/version.py
@@ -1,2 +1,2 @@
 # File that simply defines version information
-CATALOG_VERSION = '0.0.6'
+CATALOG_VERSION = '0.0.7'

--- a/lib/java/us/kbase/catalog/BuildInfo.java
+++ b/lib/java/us/kbase/catalog/BuildInfo.java
@@ -1,0 +1,132 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: BuildInfo</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "registration_id",
+    "registration",
+    "error_message",
+    "module_name",
+    "git_url"
+})
+public class BuildInfo {
+
+    @JsonProperty("registration_id")
+    private String registrationId;
+    @JsonProperty("registration")
+    private String registration;
+    @JsonProperty("error_message")
+    private String errorMessage;
+    @JsonProperty("module_name")
+    private String moduleName;
+    @JsonProperty("git_url")
+    private String gitUrl;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("registration_id")
+    public String getRegistrationId() {
+        return registrationId;
+    }
+
+    @JsonProperty("registration_id")
+    public void setRegistrationId(String registrationId) {
+        this.registrationId = registrationId;
+    }
+
+    public BuildInfo withRegistrationId(String registrationId) {
+        this.registrationId = registrationId;
+        return this;
+    }
+
+    @JsonProperty("registration")
+    public String getRegistration() {
+        return registration;
+    }
+
+    @JsonProperty("registration")
+    public void setRegistration(String registration) {
+        this.registration = registration;
+    }
+
+    public BuildInfo withRegistration(String registration) {
+        this.registration = registration;
+        return this;
+    }
+
+    @JsonProperty("error_message")
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    @JsonProperty("error_message")
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public BuildInfo withErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+        return this;
+    }
+
+    @JsonProperty("module_name")
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    @JsonProperty("module_name")
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public BuildInfo withModuleName(String moduleName) {
+        this.moduleName = moduleName;
+        return this;
+    }
+
+    @JsonProperty("git_url")
+    public String getGitUrl() {
+        return gitUrl;
+    }
+
+    @JsonProperty("git_url")
+    public void setGitUrl(String gitUrl) {
+        this.gitUrl = gitUrl;
+    }
+
+    public BuildInfo withGitUrl(String gitUrl) {
+        this.gitUrl = gitUrl;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((((("BuildInfo"+" [registrationId=")+ registrationId)+", registration=")+ registration)+", errorMessage=")+ errorMessage)+", moduleName=")+ moduleName)+", gitUrl=")+ gitUrl)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/BuildInfo.java
+++ b/lib/java/us/kbase/catalog/BuildInfo.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "registration_id",
     "registration",
     "error_message",
-    "module_name",
+    "module_name_lc",
     "git_url"
 })
 public class BuildInfo {
@@ -33,8 +33,8 @@ public class BuildInfo {
     private String registration;
     @JsonProperty("error_message")
     private String errorMessage;
-    @JsonProperty("module_name")
-    private String moduleName;
+    @JsonProperty("module_name_lc")
+    private String moduleNameLc;
     @JsonProperty("git_url")
     private String gitUrl;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
@@ -84,18 +84,18 @@ public class BuildInfo {
         return this;
     }
 
-    @JsonProperty("module_name")
-    public String getModuleName() {
-        return moduleName;
+    @JsonProperty("module_name_lc")
+    public String getModuleNameLc() {
+        return moduleNameLc;
     }
 
-    @JsonProperty("module_name")
-    public void setModuleName(String moduleName) {
-        this.moduleName = moduleName;
+    @JsonProperty("module_name_lc")
+    public void setModuleNameLc(String moduleNameLc) {
+        this.moduleNameLc = moduleNameLc;
     }
 
-    public BuildInfo withModuleName(String moduleName) {
-        this.moduleName = moduleName;
+    public BuildInfo withModuleNameLc(String moduleNameLc) {
+        this.moduleNameLc = moduleNameLc;
         return this;
     }
 
@@ -126,7 +126,7 @@ public class BuildInfo {
 
     @Override
     public String toString() {
-        return ((((((((((((("BuildInfo"+" [registrationId=")+ registrationId)+", registration=")+ registration)+", errorMessage=")+ errorMessage)+", moduleName=")+ moduleName)+", gitUrl=")+ gitUrl)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((("BuildInfo"+" [registrationId=")+ registrationId)+", registration=")+ registration)+", errorMessage=")+ errorMessage)+", moduleNameLc=")+ moduleNameLc)+", gitUrl=")+ gitUrl)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/BuildLog.java
+++ b/lib/java/us/kbase/catalog/BuildLog.java
@@ -1,0 +1,61 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: BuildLog</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "log"
+})
+public class BuildLog {
+
+    @JsonProperty("log")
+    private List<BuildLogLine> log;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("log")
+    public List<BuildLogLine> getLog() {
+        return log;
+    }
+
+    @JsonProperty("log")
+    public void setLog(List<BuildLogLine> log) {
+        this.log = log;
+    }
+
+    public BuildLog withLog(List<BuildLogLine> log) {
+        this.log = log;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((("BuildLog"+" [log=")+ log)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/BuildLog.java
+++ b/lib/java/us/kbase/catalog/BuildLog.java
@@ -20,13 +20,121 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
+    "registration_id",
+    "timestamp",
+    "module_name_lc",
+    "git_url",
+    "error",
+    "registration",
     "log"
 })
 public class BuildLog {
 
+    @JsonProperty("registration_id")
+    private String registrationId;
+    @JsonProperty("timestamp")
+    private String timestamp;
+    @JsonProperty("module_name_lc")
+    private String moduleNameLc;
+    @JsonProperty("git_url")
+    private String gitUrl;
+    @JsonProperty("error")
+    private String error;
+    @JsonProperty("registration")
+    private String registration;
     @JsonProperty("log")
     private List<BuildLogLine> log;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("registration_id")
+    public String getRegistrationId() {
+        return registrationId;
+    }
+
+    @JsonProperty("registration_id")
+    public void setRegistrationId(String registrationId) {
+        this.registrationId = registrationId;
+    }
+
+    public BuildLog withRegistrationId(String registrationId) {
+        this.registrationId = registrationId;
+        return this;
+    }
+
+    @JsonProperty("timestamp")
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    @JsonProperty("timestamp")
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public BuildLog withTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    @JsonProperty("module_name_lc")
+    public String getModuleNameLc() {
+        return moduleNameLc;
+    }
+
+    @JsonProperty("module_name_lc")
+    public void setModuleNameLc(String moduleNameLc) {
+        this.moduleNameLc = moduleNameLc;
+    }
+
+    public BuildLog withModuleNameLc(String moduleNameLc) {
+        this.moduleNameLc = moduleNameLc;
+        return this;
+    }
+
+    @JsonProperty("git_url")
+    public String getGitUrl() {
+        return gitUrl;
+    }
+
+    @JsonProperty("git_url")
+    public void setGitUrl(String gitUrl) {
+        this.gitUrl = gitUrl;
+    }
+
+    public BuildLog withGitUrl(String gitUrl) {
+        this.gitUrl = gitUrl;
+        return this;
+    }
+
+    @JsonProperty("error")
+    public String getError() {
+        return error;
+    }
+
+    @JsonProperty("error")
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public BuildLog withError(String error) {
+        this.error = error;
+        return this;
+    }
+
+    @JsonProperty("registration")
+    public String getRegistration() {
+        return registration;
+    }
+
+    @JsonProperty("registration")
+    public void setRegistration(String registration) {
+        this.registration = registration;
+    }
+
+    public BuildLog withRegistration(String registration) {
+        this.registration = registration;
+        return this;
+    }
 
     @JsonProperty("log")
     public List<BuildLogLine> getLog() {
@@ -55,7 +163,7 @@ public class BuildLog {
 
     @Override
     public String toString() {
-        return ((((("BuildLog"+" [log=")+ log)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((("BuildLog"+" [registrationId=")+ registrationId)+", timestamp=")+ timestamp)+", moduleNameLc=")+ moduleNameLc)+", gitUrl=")+ gitUrl)+", error=")+ error)+", registration=")+ registration)+", log=")+ log)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/BuildLogLine.java
+++ b/lib/java/us/kbase/catalog/BuildLogLine.java
@@ -1,0 +1,78 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: BuildLogLine</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "content",
+    "error"
+})
+public class BuildLogLine {
+
+    @JsonProperty("content")
+    private String content;
+    @JsonProperty("error")
+    private Long error;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("content")
+    public String getContent() {
+        return content;
+    }
+
+    @JsonProperty("content")
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public BuildLogLine withContent(String content) {
+        this.content = content;
+        return this;
+    }
+
+    @JsonProperty("error")
+    public Long getError() {
+        return error;
+    }
+
+    @JsonProperty("error")
+    public void setError(Long error) {
+        this.error = error;
+    }
+
+    public BuildLogLine withError(Long error) {
+        this.error = error;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("BuildLogLine"+" [content=")+ content)+", error=")+ error)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -377,7 +377,7 @@ public class CatalogClient {
     }
 
     /**
-     * <p>Original spec-file function name: get_build_log2</p>
+     * <p>Original spec-file function name: get_parsed_build_log</p>
      * <pre>
      * given the registration_id returned from the register method, you can check the build log with this method
      * </pre>
@@ -386,11 +386,11 @@ public class CatalogClient {
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public BuildLog getBuildLog2(GetBuildLogParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public BuildLog getParsedBuildLog(GetBuildLogParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
         args.add(params);
         TypeReference<List<BuildLog>> retType = new TypeReference<List<BuildLog>>() {};
-        List<BuildLog> res = caller.jsonrpcCall("Catalog.get_build_log2", args, retType, true, false, jsonRpcContext);
+        List<BuildLog> res = caller.jsonrpcCall("Catalog.get_parsed_build_log", args, retType, true, false, jsonRpcContext);
         return res.get(0);
     }
 

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -15,7 +15,7 @@ import us.kbase.common.service.UnauthorizedException;
 /**
  * <p>Original spec-file module name: Catalog</p>
  * <pre>
- * Service for managing, registering, and building KBase Modules.
+ * Service for managing, registering, and building KBase Modules using the KBase SDK.
  * </pre>
  */
 public class CatalogClient {
@@ -157,6 +157,7 @@ public class CatalogClient {
     /**
      * <p>Original spec-file function name: is_registered</p>
      * <pre>
+     * returns true (1) if the module exists, false (2) otherwise
      * </pre>
      * @param   params   instance of type {@link us.kbase.catalog.SelectOneModuleParams SelectOneModuleParams}
      * @return   instance of original type "boolean" (@range [0,1])
@@ -361,7 +362,6 @@ public class CatalogClient {
     /**
      * <p>Original spec-file function name: get_build_log</p>
      * <pre>
-     * given the registration_id returned from the register method, you can check the build log with this method
      * </pre>
      * @param   registrationId   instance of String
      * @return   instance of String
@@ -373,6 +373,41 @@ public class CatalogClient {
         args.add(registrationId);
         TypeReference<List<String>> retType = new TypeReference<List<String>>() {};
         List<String> res = caller.jsonrpcCall("Catalog.get_build_log", args, retType, true, false, jsonRpcContext);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: get_build_log2</p>
+     * <pre>
+     * given the registration_id returned from the register method, you can check the build log with this method
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.catalog.GetBuildLogParams GetBuildLogParams}
+     * @return   parameter "build_log" of type {@link us.kbase.catalog.BuildLog BuildLog}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public BuildLog getBuildLog2(GetBuildLogParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<BuildLog>> retType = new TypeReference<List<BuildLog>>() {};
+        List<BuildLog> res = caller.jsonrpcCall("Catalog.get_build_log2", args, retType, true, false, jsonRpcContext);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: list_builds</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.catalog.ListBuildParams ListBuildParams}
+     * @return   parameter "builds" of list of type {@link us.kbase.catalog.BuildInfo BuildInfo}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public List<BuildInfo> listBuilds(ListBuildParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<List<BuildInfo>>> retType = new TypeReference<List<List<BuildInfo>>>() {};
+        List<List<BuildInfo>> res = caller.jsonrpcCall("Catalog.list_builds", args, retType, true, false, jsonRpcContext);
         return res.get(0);
     }
 

--- a/lib/java/us/kbase/catalog/GetBuildLogParams.java
+++ b/lib/java/us/kbase/catalog/GetBuildLogParams.java
@@ -13,24 +13,32 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * <p>Original spec-file type: GetBuildLogParams</p>
- * 
+ * <pre>
+ * must specify skip & limit, or first_n, or last_n.  If none given, this gets last 5000 lines
+ * </pre>
  * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
     "registration_id",
-    "line_start",
-    "line_end"
+    "skip",
+    "limit",
+    "first_n",
+    "last_n"
 })
 public class GetBuildLogParams {
 
     @JsonProperty("registration_id")
     private String registrationId;
-    @JsonProperty("line_start")
-    private Long lineStart;
-    @JsonProperty("line_end")
-    private Long lineEnd;
+    @JsonProperty("skip")
+    private Long skip;
+    @JsonProperty("limit")
+    private Long limit;
+    @JsonProperty("first_n")
+    private Long firstN;
+    @JsonProperty("last_n")
+    private Long lastN;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @JsonProperty("registration_id")
@@ -48,33 +56,63 @@ public class GetBuildLogParams {
         return this;
     }
 
-    @JsonProperty("line_start")
-    public Long getLineStart() {
-        return lineStart;
+    @JsonProperty("skip")
+    public Long getSkip() {
+        return skip;
     }
 
-    @JsonProperty("line_start")
-    public void setLineStart(Long lineStart) {
-        this.lineStart = lineStart;
+    @JsonProperty("skip")
+    public void setSkip(Long skip) {
+        this.skip = skip;
     }
 
-    public GetBuildLogParams withLineStart(Long lineStart) {
-        this.lineStart = lineStart;
+    public GetBuildLogParams withSkip(Long skip) {
+        this.skip = skip;
         return this;
     }
 
-    @JsonProperty("line_end")
-    public Long getLineEnd() {
-        return lineEnd;
+    @JsonProperty("limit")
+    public Long getLimit() {
+        return limit;
     }
 
-    @JsonProperty("line_end")
-    public void setLineEnd(Long lineEnd) {
-        this.lineEnd = lineEnd;
+    @JsonProperty("limit")
+    public void setLimit(Long limit) {
+        this.limit = limit;
     }
 
-    public GetBuildLogParams withLineEnd(Long lineEnd) {
-        this.lineEnd = lineEnd;
+    public GetBuildLogParams withLimit(Long limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    @JsonProperty("first_n")
+    public Long getFirstN() {
+        return firstN;
+    }
+
+    @JsonProperty("first_n")
+    public void setFirstN(Long firstN) {
+        this.firstN = firstN;
+    }
+
+    public GetBuildLogParams withFirstN(Long firstN) {
+        this.firstN = firstN;
+        return this;
+    }
+
+    @JsonProperty("last_n")
+    public Long getLastN() {
+        return lastN;
+    }
+
+    @JsonProperty("last_n")
+    public void setLastN(Long lastN) {
+        this.lastN = lastN;
+    }
+
+    public GetBuildLogParams withLastN(Long lastN) {
+        this.lastN = lastN;
         return this;
     }
 
@@ -90,7 +128,7 @@ public class GetBuildLogParams {
 
     @Override
     public String toString() {
-        return ((((((((("GetBuildLogParams"+" [registrationId=")+ registrationId)+", lineStart=")+ lineStart)+", lineEnd=")+ lineEnd)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((("GetBuildLogParams"+" [registrationId=")+ registrationId)+", skip=")+ skip)+", limit=")+ limit)+", firstN=")+ firstN)+", lastN=")+ lastN)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/GetBuildLogParams.java
+++ b/lib/java/us/kbase/catalog/GetBuildLogParams.java
@@ -1,0 +1,96 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: GetBuildLogParams</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "registration_id",
+    "line_start",
+    "line_end"
+})
+public class GetBuildLogParams {
+
+    @JsonProperty("registration_id")
+    private String registrationId;
+    @JsonProperty("line_start")
+    private Long lineStart;
+    @JsonProperty("line_end")
+    private Long lineEnd;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("registration_id")
+    public String getRegistrationId() {
+        return registrationId;
+    }
+
+    @JsonProperty("registration_id")
+    public void setRegistrationId(String registrationId) {
+        this.registrationId = registrationId;
+    }
+
+    public GetBuildLogParams withRegistrationId(String registrationId) {
+        this.registrationId = registrationId;
+        return this;
+    }
+
+    @JsonProperty("line_start")
+    public Long getLineStart() {
+        return lineStart;
+    }
+
+    @JsonProperty("line_start")
+    public void setLineStart(Long lineStart) {
+        this.lineStart = lineStart;
+    }
+
+    public GetBuildLogParams withLineStart(Long lineStart) {
+        this.lineStart = lineStart;
+        return this;
+    }
+
+    @JsonProperty("line_end")
+    public Long getLineEnd() {
+        return lineEnd;
+    }
+
+    @JsonProperty("line_end")
+    public void setLineEnd(Long lineEnd) {
+        this.lineEnd = lineEnd;
+    }
+
+    public GetBuildLogParams withLineEnd(Long lineEnd) {
+        this.lineEnd = lineEnd;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("GetBuildLogParams"+" [registrationId=")+ registrationId)+", lineStart=")+ lineStart)+", lineEnd=")+ lineEnd)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/ListBuildParams.java
+++ b/lib/java/us/kbase/catalog/ListBuildParams.java
@@ -16,8 +16,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <p>Original spec-file type: ListBuildParams</p>
  * <pre>
  * Always sorted by time, oldest builds are last.
- *         only_running - if true, only show running builds
- *         only_error - if true, only show builds that ended in an error
+ * only one of these can be set to true:
+ *     only_running - if true, only show running builds
+ *     only_error - if true, only show builds that ended in an error
+ *     only_complete - if true, only show builds that are complete
+ * skip - skip these first n records, default 0
+ * limit - limit result to the most recent n records, default 1000
+ * modules - only include builds from these modules based on names/git_urls
  * </pre>
  * 
  */

--- a/lib/java/us/kbase/catalog/ListBuildParams.java
+++ b/lib/java/us/kbase/catalog/ListBuildParams.java
@@ -1,0 +1,155 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ListBuildParams</p>
+ * <pre>
+ * Always sorted by time, oldest builds are last.
+ *         only_running - if true, only show running builds
+ *         only_error - if true, only show builds that ended in an error
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "only_runnning",
+    "only_error",
+    "only_complete",
+    "skip",
+    "limit",
+    "modules"
+})
+public class ListBuildParams {
+
+    @JsonProperty("only_runnning")
+    private Long onlyRunnning;
+    @JsonProperty("only_error")
+    private Long onlyError;
+    @JsonProperty("only_complete")
+    private Long onlyComplete;
+    @JsonProperty("skip")
+    private Long skip;
+    @JsonProperty("limit")
+    private Long limit;
+    @JsonProperty("modules")
+    private List<SelectOneModuleParams> modules;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("only_runnning")
+    public Long getOnlyRunnning() {
+        return onlyRunnning;
+    }
+
+    @JsonProperty("only_runnning")
+    public void setOnlyRunnning(Long onlyRunnning) {
+        this.onlyRunnning = onlyRunnning;
+    }
+
+    public ListBuildParams withOnlyRunnning(Long onlyRunnning) {
+        this.onlyRunnning = onlyRunnning;
+        return this;
+    }
+
+    @JsonProperty("only_error")
+    public Long getOnlyError() {
+        return onlyError;
+    }
+
+    @JsonProperty("only_error")
+    public void setOnlyError(Long onlyError) {
+        this.onlyError = onlyError;
+    }
+
+    public ListBuildParams withOnlyError(Long onlyError) {
+        this.onlyError = onlyError;
+        return this;
+    }
+
+    @JsonProperty("only_complete")
+    public Long getOnlyComplete() {
+        return onlyComplete;
+    }
+
+    @JsonProperty("only_complete")
+    public void setOnlyComplete(Long onlyComplete) {
+        this.onlyComplete = onlyComplete;
+    }
+
+    public ListBuildParams withOnlyComplete(Long onlyComplete) {
+        this.onlyComplete = onlyComplete;
+        return this;
+    }
+
+    @JsonProperty("skip")
+    public Long getSkip() {
+        return skip;
+    }
+
+    @JsonProperty("skip")
+    public void setSkip(Long skip) {
+        this.skip = skip;
+    }
+
+    public ListBuildParams withSkip(Long skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    @JsonProperty("limit")
+    public Long getLimit() {
+        return limit;
+    }
+
+    @JsonProperty("limit")
+    public void setLimit(Long limit) {
+        this.limit = limit;
+    }
+
+    public ListBuildParams withLimit(Long limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    @JsonProperty("modules")
+    public List<SelectOneModuleParams> getModules() {
+        return modules;
+    }
+
+    @JsonProperty("modules")
+    public void setModules(List<SelectOneModuleParams> modules) {
+        this.modules = modules;
+    }
+
+    public ListBuildParams withModules(List<SelectOneModuleParams> modules) {
+        this.modules = modules;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((((((("ListBuildParams"+" [onlyRunnning=")+ onlyRunnning)+", onlyError=")+ onlyError)+", onlyComplete=")+ onlyComplete)+", skip=")+ skip)+", limit=")+ limit)+", modules=")+ modules)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/ModuleState.java
+++ b/lib/java/us/kbase/catalog/ModuleState.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "release_approval",
     "review_message",
     "registration",
-    "last_registration_id",
     "error_message"
 })
 public class ModuleState {
@@ -45,8 +44,6 @@ public class ModuleState {
     private String reviewMessage;
     @JsonProperty("registration")
     private String registration;
-    @JsonProperty("last_registration_id")
-    private String lastRegistrationId;
     @JsonProperty("error_message")
     private String errorMessage;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
@@ -126,21 +123,6 @@ public class ModuleState {
         return this;
     }
 
-    @JsonProperty("last_registration_id")
-    public String getLastRegistrationId() {
-        return lastRegistrationId;
-    }
-
-    @JsonProperty("last_registration_id")
-    public void setLastRegistrationId(String lastRegistrationId) {
-        this.lastRegistrationId = lastRegistrationId;
-    }
-
-    public ModuleState withLastRegistrationId(String lastRegistrationId) {
-        this.lastRegistrationId = lastRegistrationId;
-        return this;
-    }
-
     @JsonProperty("error_message")
     public String getErrorMessage() {
         return errorMessage;
@@ -168,7 +150,7 @@ public class ModuleState {
 
     @Override
     public String toString() {
-        return ((((((((((((((((("ModuleState"+" [active=")+ active)+", released=")+ released)+", releaseApproval=")+ releaseApproval)+", reviewMessage=")+ reviewMessage)+", registration=")+ registration)+", lastRegistrationId=")+ lastRegistrationId)+", errorMessage=")+ errorMessage)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((("ModuleState"+" [active=")+ active)+", released=")+ released)+", releaseApproval=")+ releaseApproval)+", reviewMessage=")+ reviewMessage)+", registration=")+ registration)+", errorMessage=")+ errorMessage)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/ModuleState.java
+++ b/lib/java/us/kbase/catalog/ModuleState.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * active: True | False,
  * release_approval: approved | denied | under_review | not_requested, (all releases require approval)
  * review_message: str, (optional)
- * registration: building | complete | error,
+ * registration: complete | error | (build state status),
  * error_message: str (optional)
  * </pre>
  * 
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "release_approval",
     "review_message",
     "registration",
+    "last_registration_id",
     "error_message"
 })
 public class ModuleState {
@@ -44,6 +45,8 @@ public class ModuleState {
     private String reviewMessage;
     @JsonProperty("registration")
     private String registration;
+    @JsonProperty("last_registration_id")
+    private String lastRegistrationId;
     @JsonProperty("error_message")
     private String errorMessage;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
@@ -123,6 +126,21 @@ public class ModuleState {
         return this;
     }
 
+    @JsonProperty("last_registration_id")
+    public String getLastRegistrationId() {
+        return lastRegistrationId;
+    }
+
+    @JsonProperty("last_registration_id")
+    public void setLastRegistrationId(String lastRegistrationId) {
+        this.lastRegistrationId = lastRegistrationId;
+    }
+
+    public ModuleState withLastRegistrationId(String lastRegistrationId) {
+        this.lastRegistrationId = lastRegistrationId;
+        return this;
+    }
+
     @JsonProperty("error_message")
     public String getErrorMessage() {
         return errorMessage;
@@ -150,7 +168,7 @@ public class ModuleState {
 
     @Override
     public String toString() {
-        return ((((((((((((((("ModuleState"+" [active=")+ active)+", released=")+ released)+", releaseApproval=")+ releaseApproval)+", reviewMessage=")+ reviewMessage)+", registration=")+ registration)+", errorMessage=")+ errorMessage)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((("ModuleState"+" [active=")+ active)+", released=")+ released)+", releaseApproval=")+ releaseApproval)+", reviewMessage=")+ reviewMessage)+", registration=")+ registration)+", lastRegistrationId=")+ lastRegistrationId)+", errorMessage=")+ errorMessage)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/ModuleVersionInfo.java
+++ b/lib/java/us/kbase/catalog/ModuleVersionInfo.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
     "timestamp",
+    "registration_id",
     "version",
     "git_commit_hash",
     "git_commit_message",
@@ -31,6 +32,8 @@ public class ModuleVersionInfo {
 
     @JsonProperty("timestamp")
     private Long timestamp;
+    @JsonProperty("registration_id")
+    private java.lang.String registrationId;
     @JsonProperty("version")
     private java.lang.String version;
     @JsonProperty("git_commit_hash")
@@ -55,6 +58,21 @@ public class ModuleVersionInfo {
 
     public ModuleVersionInfo withTimestamp(Long timestamp) {
         this.timestamp = timestamp;
+        return this;
+    }
+
+    @JsonProperty("registration_id")
+    public java.lang.String getRegistrationId() {
+        return registrationId;
+    }
+
+    @JsonProperty("registration_id")
+    public void setRegistrationId(java.lang.String registrationId) {
+        this.registrationId = registrationId;
+    }
+
+    public ModuleVersionInfo withRegistrationId(java.lang.String registrationId) {
+        this.registrationId = registrationId;
         return this;
     }
 
@@ -145,7 +163,7 @@ public class ModuleVersionInfo {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((("ModuleVersionInfo"+" [timestamp=")+ timestamp)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", gitCommitMessage=")+ gitCommitMessage)+", narrativeMethodIds=")+ narrativeMethodIds)+", dockerImgName=")+ dockerImgName)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((("ModuleVersionInfo"+" [timestamp=")+ timestamp)+", registrationId=")+ registrationId)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", gitCommitMessage=")+ gitCommitMessage)+", narrativeMethodIds=")+ narrativeMethodIds)+", dockerImgName=")+ dockerImgName)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/SelectOneModuleParams.java
+++ b/lib/java/us/kbase/catalog/SelectOneModuleParams.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * <p>Original spec-file type: SelectOneModuleParams</p>
  * <pre>
- * Describes how to find module/repository.
+ * Describes how to find a single module/repository.
  * module_name - name of module defined in kbase.yaml file;
  * git_url - the url used to register the module
  * </pre>

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -195,6 +195,32 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             [registration_id], 1, _callback, _errorCallback);
     };
  
+     this.get_build_log2 = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.get_build_log2",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.list_builds = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.list_builds",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
      this.delete_module = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -195,7 +195,7 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             [registration_id], 1, _callback, _errorCallback);
     };
  
-     this.get_build_log2 = function (params, _callback, _errorCallback) {
+     this.get_parsed_build_log = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';
         if (_callback && typeof _callback !== 'function')
@@ -204,7 +204,7 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms) {
             throw 'Argument _errorCallback must be a function if defined';
         if (typeof arguments === 'function' && arguments.length > 1+2)
             throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
-        return json_call_ajax("Catalog.get_build_log2",
+        return json_call_ajax("Catalog.get_parsed_build_log",
             [params], 1, _callback, _errorCallback);
     };
  

--- a/test/admin_methods_test.py
+++ b/test/admin_methods_test.py
@@ -64,15 +64,14 @@ class AdminMethodsTest(unittest.TestCase):
         # should block registration for non-developers
         with self.assertRaises(ValueError):
             self.catalog.register_repo(self.cUtil.user_ctx(),
-                {'git_url':'https://madeupurl.com'})
+                {'git_url':self.cUtil.get_test_repo_1()})
 
         # after the developer is added, should be allowed to start now (give a bogus url so if finishes registration
         # right away with an error
         self.catalog.approve_developer(self.cUtil.admin_ctx(),self.cUtil.test_user_1)
-        self.catalog.register_repo(self.cUtil.user_ctx(),{'git_url':'https://madeupurl.com'})
+        self.catalog.register_repo(self.cUtil.user_ctx(),{'git_url':self.cUtil.get_test_repo_1(),'commit_hash':'0760f1927f74a'})
         while True:
-            state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),{'git_url':'https://madeupurl.com'})[0]
-            #pprint(state)
+            state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),{'git_url':self.cUtil.get_test_repo_1()})[0]
             if state['registration'] in ['complete','error']:
                 break
 
@@ -208,9 +207,11 @@ class AdminMethodsTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        print('++++++++++++ RUNNING admin_methods_test.py +++++++++++')
         cls.cUtil = CatalogTestUtil('.') # TODO: pass in test directory from outside
         cls.cUtil.setUp()
         cls.catalog = Catalog(cls.cUtil.getCatalogConfig())
+        print('ready')
 
     @classmethod
     def tearDownClass(cls):

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -14,7 +14,7 @@ class BasicCatalogTest(unittest.TestCase):
 
 
     def test_version(self):
-        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.6'])
+        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.7'])
 
 
     def test_is_registered(self):

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -446,6 +446,7 @@ class BasicCatalogTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        print('++++++++++++ RUNNING basic_catalog_test.py +++++++++++')
         cls.cUtil = CatalogTestUtil('.') # TODO: pass in test directory from outside
         cls.cUtil.setUp()
         cls.catalog = Catalog(cls.cUtil.getCatalogConfig())

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -47,9 +47,12 @@ class CatalogTestUtil:
         db = self.mongo[self.test_cfg['mongodb-database']]
         self.modules = db[MongoCatalogDBI._MODULES]
         self.developers = db[MongoCatalogDBI._DEVELOPERS]
+        self.build_logs = db[MongoCatalogDBI._BUILD_LOGS]
         # just drop the test db
         self.modules.drop()
         self.developers.drop()
+        self.build_logs.drop()
+
         #if self.modules.count() > 0 :
         #    raise ValueError('mongo database collection "'+MongoCatalogDBI._MODULES+'"" not empty (contains '+str(self.modules.count())+' records).  aborting.')
 
@@ -124,6 +127,7 @@ class CatalogTestUtil:
         self.log("tearDown()")
         self.modules.drop()
         self.developers.drop()
+        self.build_logs.drop()
         # make sure NMS is clean after each test
         self.mongo.drop_database(self.nms_test_cfg['method-spec-mongo-dbname'])
 

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -95,6 +95,16 @@ class CatalogTestUtil:
                 self.modules.insert(parsed_document)
                 load_count+=1
 
+        logs_document_dir = os.path.join(self.test_dir, 'initial_mongo_state', MongoCatalogDBI._BUILD_LOGS)
+        for document_name in os.listdir(logs_document_dir):
+            document_path = os.path.join(logs_document_dir,document_name)
+            if os.path.isfile(document_path):
+                with open(document_path) as document_file:
+                    document = document_file.read()
+                parsed_document = json.loads(document)
+                self.build_logs.insert(parsed_document)
+                load_count+=1
+
         self.log(str(load_count)+" documents loaded")
 
 

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -345,6 +345,8 @@ class CoreRegistrationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
+        print('++++++++++++ RUNNING core_registration_test.py +++++++++++')
+
         # hack for testing!! remove when docker and NMS components can be tested
         from biokbase.catalog.registrar import Registrar
         Registrar._TEST_WITHOUT_DOCKER = True

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -89,6 +89,17 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(parsed_log['log'][4],parsed_log_subset['log'][0])
         self.assertEqual(parsed_log['log'][5],parsed_log_subset['log'][1])
 
+        # should show up as the top hit when we list logs
+        recent_build_list = self.catalog.list_builds(self.cUtil.anonymous_ctx(),{'limit':6})[0]
+
+        self.assertEqual(len(recent_build_list),6)
+        self.assertEqual(recent_build_list[0]['registration_id'],registration_id)
+        self.assertEqual(recent_build_list[0]['registration'],'complete')
+        self.assertEqual(recent_build_list[0]['error_message'],'')
+        self.assertIsNotNone(recent_build_list[0]['module_name_lc'])
+        self.assertEqual(recent_build_list[0]['git_url'],giturl)
+
+
         # check some bad parameters
         with self.assertRaises(ValueError):
             parsed_log_subset = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -36,8 +36,67 @@ class CoreRegistrationTest(unittest.TestCase):
                 break
             self.assertTrue(time()-start < timeout, 'simple registration build exceeded timeout of '+str(timeout)+'s')
         self.assertEqual(state['registration'],'complete')
-        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),registration_id)
-        self.assertTrue(log is not None)
+
+        # (3) check the log
+        parsed_log = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),
+                            {'registration_id':registration_id})[0]
+        self.assertEqual(parsed_log['registration'],'complete')
+        self.assertEqual(parsed_log['registration_id'],registration_id)
+        self.assertEqual(parsed_log['git_url'],giturl)
+        self.assertEqual(parsed_log['error_message'],'')
+        self.assertIsNotNone(parsed_log['module_name_lc'])
+        self.assertTrue(len(parsed_log['log'])>0)
+
+        # get the log file directly
+        raw_log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),registration_id)[0]
+        self.assertTrue(raw_log is not None)
+
+        log_lines = raw_log.splitlines();
+        self.assertTrue(log_lines, parsed_log['log'])
+
+        # check getting specific lines
+        parsed_log_subset = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),
+                            {
+                                'registration_id':registration_id, 
+                                'first_n':5 
+                            })[0]
+        self.assertEqual(len(parsed_log_subset['log']),5)
+        self.assertEqual(parsed_log['log'][0],parsed_log_subset['log'][0])
+        self.assertEqual(parsed_log['log'][1],parsed_log_subset['log'][1])
+        self.assertEqual(parsed_log['log'][2],parsed_log_subset['log'][2])
+        self.assertEqual(parsed_log['log'][3],parsed_log_subset['log'][3])
+        self.assertEqual(parsed_log['log'][4],parsed_log_subset['log'][4])
+
+        parsed_log_subset = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),
+                            {
+                                'registration_id':registration_id, 
+                                'last_n':5 
+                            })[0]
+        self.assertEqual(len(parsed_log_subset['log']),5)
+        self.assertEqual(parsed_log['log'][-1],parsed_log_subset['log'][4])
+        self.assertEqual(parsed_log['log'][-2],parsed_log_subset['log'][3])
+        self.assertEqual(parsed_log['log'][-3],parsed_log_subset['log'][2])
+        self.assertEqual(parsed_log['log'][-4],parsed_log_subset['log'][1])
+        self.assertEqual(parsed_log['log'][-5],parsed_log_subset['log'][0])
+
+        parsed_log_subset = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),
+                            {
+                                'registration_id':registration_id, 
+                                'skip':4,
+                                'limit':2 
+                            })[0]
+        self.assertEqual(len(parsed_log_subset['log']),2)
+        self.assertEqual(parsed_log['log'][4],parsed_log_subset['log'][0])
+        self.assertEqual(parsed_log['log'][5],parsed_log_subset['log'][1])
+
+        # check some bad parameters
+        with self.assertRaises(ValueError):
+            parsed_log_subset = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),
+                            {'registration_id':registration_id, 'skip':4 })[0]
+        with self.assertRaises(ValueError):
+            parsed_log_subset = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),
+                            {'registration_id':registration_id, 'first_n':4, 'last_n':2 })[0]
+
 
         # (3) get module info
         info = self.catalog.get_module_info(self.cUtil.anonymous_ctx(),{'git_url':giturl})[0]

--- a/test/initial_mongo_state/build_logs/onerepotest_log1.json
+++ b/test/initial_mongo_state/build_logs/onerepotest_log1.json
@@ -1,0 +1,18 @@
+{   
+    "error_message" : "",
+    "git_url" : "https://github.com/kbaseIncubator/onerepotest",
+    "log" : [
+        {
+            "content" : "did stuff line 1",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 2",
+            "error" : false
+        }
+    ],
+    "module_name_lc" : "onerepotest",
+    "registration" : "complete",
+    "registration_id" : "1445024094055_7215",
+    "timestamp" : 1445024094055
+}

--- a/test/initial_mongo_state/build_logs/onerepotest_log2.json
+++ b/test/initial_mongo_state/build_logs/onerepotest_log2.json
@@ -1,0 +1,18 @@
+{   
+    "error_message" : "",
+    "git_url" : "https://github.com/kbaseIncubator/onerepotest",
+    "log" : [
+        {
+            "content" : "did stuff line 1",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 2",
+            "error" : false
+        }
+    ],
+    "module_name_lc" : "onerepotest",
+    "registration" : "complete",
+    "registration_id" : "1445023985597_1245",
+    "timestamp" : 1445023985597
+}

--- a/test/initial_mongo_state/build_logs/onerepotest_log3.json
+++ b/test/initial_mongo_state/build_logs/onerepotest_log3.json
@@ -1,0 +1,26 @@
+{   
+    "error_message" : "",
+    "git_url" : "https://github.com/kbaseIncubator/onerepotest",
+    "log" : [
+        {
+            "content" : "did stuff line 1",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 2",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 3",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 4",
+            "error" : false
+        }
+    ],
+    "module_name_lc" : "onerepotest",
+    "registration" : "complete",
+    "registration_id" : "1445022818884_1245",
+    "timestamp" : 1445022818884
+}

--- a/test/initial_mongo_state/build_logs/registration_in_progress_log1.json
+++ b/test/initial_mongo_state/build_logs/registration_in_progress_log1.json
@@ -1,0 +1,22 @@
+{   
+    "error_message" : "",
+    "git_url" : "https://github.com/kbaseIncubator/registration_in_progress",
+    "log" : [
+        {
+            "content" : "did stuff line 1",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 2",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 3",
+            "error" : false
+        }
+    ],
+    "module_name_lc" : "registration_in_progress",
+    "registration" : "building some stuff",
+    "registration_id" : "1445024094055_3333",
+    "timestamp" : 1445024094055
+}

--- a/test/initial_mongo_state/build_logs/registration_in_progress_log2.json
+++ b/test/initial_mongo_state/build_logs/registration_in_progress_log2.json
@@ -1,0 +1,30 @@
+{   
+    "error_message" : "",
+    "git_url" : "https://github.com/kbaseIncubator/registration_in_progress",
+    "log" : [
+        {
+            "content" : "did stuff line 1",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 2",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 3",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 4",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 5",
+            "error" : false
+        }
+    ],
+    "module_name_lc" : "registration_in_progress",
+    "registration" : "complete",
+    "registration_id" : "1445023985597_2121",
+    "timestamp" : 1445023985597
+}

--- a/test/initial_mongo_state/build_logs/registrationerror_log1.json
+++ b/test/initial_mongo_state/build_logs/registrationerror_log1.json
@@ -1,0 +1,26 @@
+{   
+    "error_message" : "everything did't work",
+    "git_url" : "https://github.com/kbaseIncubator/registration_error",
+    "log" : [
+        {
+            "content" : "did stuff line 1",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 2",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 3",
+            "error" : false
+        },
+        {
+            "content" : "some error happened",
+            "error" : true
+        }
+    ],
+    "module_name_lc" : "registration_error",
+    "registration" : "error",
+    "registration_id" : "1445024094055_8888",
+    "timestamp" : 1445024094055
+}

--- a/test/initial_mongo_state/build_logs/registrationerror_log2.json
+++ b/test/initial_mongo_state/build_logs/registrationerror_log2.json
@@ -1,0 +1,26 @@
+{   
+    "error_message" : "",
+    "git_url" : "https://github.com/kbaseIncubator/registration_error",
+    "log" : [
+        {
+            "content" : "did stuff line 1",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 2",
+            "error" : false
+        },
+        {
+            "content" : "did stuff line 3",
+            "error" : false
+        },
+        {
+            "content" : "some error didn't happen",
+            "error" : false
+        }
+    ],
+    "module_name_lc" : "registration_error",
+    "registration" : "complete",
+    "registration_id" : "1445023985597_7881",
+    "timestamp" : 1445023985597
+}

--- a/test/initial_mongo_state/modules/denied_release.json
+++ b/test/initial_mongo_state/modules/denied_release.json
@@ -30,6 +30,8 @@
         "dev" : {
             "git_commit_hash" : "b06c5f9daf603a4d206071787c3f6184000bf128",
             "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_4321",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:denied_release.b06c5f9daf603a4d206071787c3f6184000bf128",
             "git_commit_message" : "another change",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -39,6 +41,8 @@
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_4322",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:denied_release.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/inactive_module.json
+++ b/test/initial_mongo_state/modules/inactive_module.json
@@ -27,6 +27,8 @@
         "dev" : {
             "git_commit_hash" : "b06c5f9daf603a4d206071787c3f6184000bf128",
             "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_4321",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:inactive_module.b06c5f9daf603a4d206071787c3f6184000bf128",
             "git_commit_message" : "another change",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -36,6 +38,8 @@
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_4321",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:inactive_module.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/onerepotest.json
+++ b/test/initial_mongo_state/modules/onerepotest.json
@@ -30,6 +30,7 @@
         "dev" : {
             "git_commit_hash" : "b06c5f9daf603a4d206071787c3f6184000bf128",
             "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_7215",
             "git_commit_message" : "another change",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -39,6 +40,7 @@
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_1245",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -48,6 +50,7 @@
         "release" : {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
+            "registration_id" : "1445022818884_1245",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -60,6 +63,7 @@
         "1445022818884" : {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
+            "registration_id" : "1445022818884_1245",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/onerepotest.json
+++ b/test/initial_mongo_state/modules/onerepotest.json
@@ -32,6 +32,7 @@
             "timestamp" : 1445024094055,
             "registration_id" : "1445024094055_7215",
             "git_commit_message" : "another change",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:onerepotest.b06c5f9daf603a4d206071787c3f6184000bf128",
             "version" : "0.0.1",
             "narrative_methods" : [
                 "send_data"
@@ -41,6 +42,7 @@
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
             "registration_id" : "1445023985597_1245",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:onerepotest.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -51,6 +53,7 @@
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
             "registration_id" : "1445022818884_1245",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:onerepotest.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -64,6 +67,7 @@
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
             "registration_id" : "1445022818884_1245",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:onerepotest.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/pending_first_release.json
+++ b/test/initial_mongo_state/modules/pending_first_release.json
@@ -26,6 +26,8 @@
         "dev" : {
             "git_commit_hash" : "b06c5f9daf603a4d206071787c3f6184000bf128",
             "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_4212",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:pending_first_release.b06c5f9daf603a4d206071787c3f6184000bf128",
             "git_commit_message" : "another change",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -35,6 +37,8 @@
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_4212",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:pending_first_release.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/pending_second_release.json
+++ b/test/initial_mongo_state/modules/pending_second_release.json
@@ -30,6 +30,8 @@
         "dev" : {
             "git_commit_hash" : "b06c5f9daf603a4d206071787c3f6184000bf128",
             "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:pending_second_release.b06c5f9daf603a4d206071787c3f6184000bf128",
             "git_commit_message" : "another change",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -39,6 +41,8 @@
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_4212",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:pending_second_release.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -48,6 +52,8 @@
         "release" : {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
+            "registration_id" : "1445022818884_4212",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:pending_second_release.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.1",
             "narrative_methods" : [
@@ -60,6 +66,8 @@
         "1445022818884" : {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
+            "registration_id" : "1445022818884_4212",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:pending_second_release.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/registration_error.json
+++ b/test/initial_mongo_state/modules/registration_error.json
@@ -32,6 +32,7 @@
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
             "registration_id" : "1445023985597_7881",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:registration_error.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/registration_error.json
+++ b/test/initial_mongo_state/modules/registration_error.json
@@ -25,11 +25,13 @@
 
     "current_versions" : {
         "dev" : {
-            "timestamp" : 1445024094055
+            "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_8888"
         },
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_7881",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/registration_in_progress.json
+++ b/test/initial_mongo_state/modules/registration_in_progress.json
@@ -25,11 +25,13 @@
 
     "current_versions" : {
         "dev" : {
-            "timestamp" : 1445024094055
+            "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_3333"
         },
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_2121",
             "git_commit_message" : "update for testing",
             "version" : "0.0.1",
             "narrative_methods" : [

--- a/test/initial_mongo_state/modules/release_history.json
+++ b/test/initial_mongo_state/modules/release_history.json
@@ -30,6 +30,8 @@
         "dev" : {
             "git_commit_hash" : "b06c5f9daf603a4d206071787c3f6184000bf128",
             "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.b06c5f9daf603a4d206071787c3f6184000bf128",
             "git_commit_message" : "another change",
             "version" : "0.0.5",
             "narrative_methods" : [
@@ -39,6 +41,8 @@
         "beta" : {
             "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
             "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.4",
             "narrative_methods" : [
@@ -48,6 +52,8 @@
         "release" : {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
+            "registration_id" : "1445022818884_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.3",
             "narrative_methods" : [
@@ -60,6 +66,8 @@
         "1445022818884" : {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
+            "registration_id" : "1445022818884_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "0.0.3",
             "narrative_methods" : [
@@ -70,6 +78,8 @@
         "1445022818000" : {
             "git_commit_hash" : "d6cd1e2bd19e03a81132a23b2025920577f84e37",
             "timestamp" : 1445022818000,
+            "registration_id" : "1445022818000_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.d6cd1e2bd19e03a81132a23b2025920577f84e37",
             "git_commit_message" : "something else",
             "version" : "0.0.2",
             "narrative_methods" : [
@@ -80,6 +90,8 @@
         "1445022815000" : {
             "git_commit_hash" : "9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
             "timestamp" : 1445022815000,
+            "registration_id" : "1445022815000_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
             "git_commit_message" : "and another thing",
             "version" : "0.0.1",
             "narrative_methods" : [


### PR DESCRIPTION
Improved the basic catalog API and handling of build logs.  We can now query to get a list of builds, which we can filter in a few different ways.  Logs are also permanently stored.

This PR also fixes several smaller bugs that were found during this work.