### PR TITLE
Update base image name

### DIFF
--- a/lib/biokbase/catalog/registrar.py
+++ b/lib/biokbase/catalog/registrar.py
@@ -103,7 +103,7 @@ class Registrar:
             # 3 docker build - in progress
             # perhaps make this a self attr?
             module_name_lc = self.get_required_field_as_string(self.kb_yaml,'module-name').strip().lower()
-            self.image_name = self.docker_registry_host + '/' + module_name_lc + ':' + str(git_commit_hash)
+            self.image_name = self.docker_registry_host + '/kbase:' + module_name_lc + '.' + str(git_commit_hash)
             if not Registrar._TEST_WITHOUT_DOCKER:
                 # timeout set to 30 min because we often get timeouts if multiple people try to push at the same time
                 dockerclient = None

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -121,7 +121,7 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(info['dev']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['dev']['version'],'0.0.1')
         self.assertEqual(info['dev']['timestamp'],timestamp)
-        self.assertEqual(info['dev']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
+        self.assertEqual(info['dev']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
         # the method should appear in the NMS under the dev tag
         method_list = self.nms.list_methods({'tag':'dev'})
@@ -157,13 +157,12 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(info['dev']['version'],'0.0.1')
         self.assertEqual(info['dev']['timestamp'],timestamp)
 
-        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
+        self.assertEqual(info['beta']['docker_img_name'].split('/')[1], 'kbase:' + module_name.lower()+'.'+githash)
         self.assertEqual(info['beta']['git_commit_hash'],githash)
         self.assertEqual(info['beta']['git_commit_message'],'added some basic things\n')
         self.assertEqual(info['beta']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['beta']['version'],'0.0.1')
         self.assertEqual(info['beta']['timestamp'],timestamp)
-        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
 
         # the method should appear in the NMS under the dev or beta tag
         method_list = self.nms.list_methods({'tag':'dev'})
@@ -248,33 +247,31 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(info['dev']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['dev']['version'],'0.0.1')
         self.assertEqual(info['dev']['timestamp'],timestamp)
+        self.assertEqual(info['dev']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
-        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
         self.assertEqual(info['beta']['git_commit_hash'],githash)
         self.assertEqual(info['beta']['git_commit_message'],'added some basic things\n')
         self.assertEqual(info['beta']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['beta']['version'],'0.0.1')
         self.assertEqual(info['beta']['timestamp'],timestamp)
-        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
+        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
-        self.assertEqual(info['release']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
         self.assertEqual(info['release']['git_commit_hash'],githash)
         self.assertEqual(info['release']['git_commit_message'],'added some basic things\n')
         self.assertEqual(info['release']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['release']['version'],'0.0.1')
         self.assertEqual(info['release']['timestamp'],timestamp)
-        self.assertEqual(info['release']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
+        self.assertEqual(info['release']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
         versions = self.catalog.list_released_module_versions(self.cUtil.anonymous_ctx(),{'module_name':module_name})[0]
         self.assertEqual(len(versions),1)
 
-        self.assertEqual(versions[0]['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
         self.assertEqual(versions[0]['git_commit_hash'],githash)
         self.assertEqual(versions[0]['git_commit_message'],'added some basic things\n')
         self.assertEqual(versions[0]['narrative_methods'],['test_method_1'])
         self.assertEqual(versions[0]['version'],'0.0.1')
         self.assertEqual(versions[0]['timestamp'],timestamp)
-        self.assertEqual(versions[0]['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
+        self.assertEqual(versions[0]['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
         # the method should appear in the NMS under the dev/beta/release
         method_list = self.nms.list_methods({'tag':'dev'})
@@ -322,22 +319,21 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(info['dev']['narrative_methods'],['test_method_1','test_method_2'])
         self.assertEqual(info['dev']['version'],'0.0.2')
         self.assertEqual(info['dev']['timestamp'],timestamp2)
+        self.assertEqual(info['dev']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash2)
 
-        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
         self.assertEqual(info['beta']['git_commit_hash'],githash)
         self.assertEqual(info['beta']['git_commit_message'],'added some basic things\n')
         self.assertEqual(info['beta']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['beta']['version'],'0.0.1')
         self.assertEqual(info['beta']['timestamp'],timestamp)
-        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
+        self.assertEqual(info['beta']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
-        self.assertEqual(info['release']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
         self.assertEqual(info['release']['git_commit_hash'],githash)
         self.assertEqual(info['release']['git_commit_message'],'added some basic things\n')
         self.assertEqual(info['release']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['release']['version'],'0.0.1')
         self.assertEqual(info['release']['timestamp'],timestamp)
-        self.assertEqual(info['release']['docker_img_name'].split('/')[1],module_name.lower()+':'+githash)
+        self.assertEqual(info['release']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
     def validate_basic_test_module_info_fields(self,info,giturl,module_name,owners):
         self.assertEqual(info['git_url'],giturl)


### PR DESCRIPTION
Instead of having a project name based on an SDK module name, we now make all modules docker image using the 'kbase' project, and a tag name based on the module name and commit hash.

Changing this naming scheme allows first registration and push to docker registry to use the cached sdkbase image, speeding up what used to take 15min (or more as multiple people register) to less than a minute, of course depending on what is added in the new docker build.