### PR TITLE
Add Semantic Version checks, plus bug fixes and improved tests - WIP

### DIFF
--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -316,9 +316,12 @@ class CatalogController:
         # here because if this is done twice (for instance, before the release_state is set to approved in
         # the document in the next call) there won't be any problems.)  I like nested parentheses.
         if review['decision']=='approved':
+            release_timestamp = int((datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds()*1000)
             self.nms.push_repo_to_tag({'module_name':module_details['module_name'], 'tag':'release'})
-            error = self.db.push_beta_to_release(module_name=review['module_name'],git_url=review['git_url'])
-
+            error = self.db.push_beta_to_release(
+                        module_name=review['module_name'],
+                        git_url=review['git_url'],
+                        release_timestamp=release_timestamp)
 
         # Now we can update the release state state...
         error = self.db.set_module_release_state(

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -603,7 +603,7 @@ class CatalogController:
 
     def delete_module(self,params,username):
         if not self.is_admin(username):
-            raise ValueError('Only Admin users can migrate module git urls.')
+            raise ValueError('Only Admin users can delete modules.')
         if 'module_name' not in params and 'git_url' not in params:
             raise ValueError('You must specify the "module_name" or "git_url" of the module to delete.')
         params = self.filter_module_or_repo_selection(params)

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -6,6 +6,7 @@ import time
 import copy
 import os
 import random
+import semantic_version
 
 import biokbase.catalog.version
 
@@ -250,6 +251,14 @@ class CatalogController:
         if module_details['current_versions']['release']:
             if module_details['current_versions']['beta']['timestamp'] == module_details['current_versions']['release']['timestamp']:
                 raise ValueError('Cannot request release - beta version is identical to released version.')
+            if module_details['current_versions']['beta']['version'] == module_details['current_versions']['release']['version']:
+                raise ValueError('Cannot request release - beta version has same version number to released version.')
+            # check that the version number actually increased (assume at this point we already confirmed semantic version was correct)
+            beta_sv = semantic_version.Version(module_details['current_versions']['beta']['version'])
+            release_sv = semantic_version.Version(module_details['current_versions']['release']['version'])
+            if beta_sv <= release_sv:
+                raise ValueError('Cannot request release - beta version semantic version must be greater '
+                    +'than the released version semantic version, as determined by http://semver.org')
 
         # ok, do it.
         error = self.db.set_module_release_state(

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -493,9 +493,9 @@ class CatalogController:
         # if set to inactive, disable the repo in NMS
         if(not active):
             self.nms.disable_repo({'module_name':module_details['module_name']})
-        # if set to active, enable the repo (method does not yet exist!)
-        #else:
-        #    self.nms.enable_repo({'module_name':module_details['module_name']})
+        # if set to active, enable the repo
+        else:
+            self.nms.enable_repo({'module_name':module_details['module_name']})
 
 
     def approve_developer(self, developer, username):

--- a/lib/biokbase/catalog/registrar.py
+++ b/lib/biokbase/catalog/registrar.py
@@ -7,6 +7,7 @@ import time
 import datetime
 import pprint
 import json
+import semantic_version
 
 import git
 import yaml
@@ -202,6 +203,11 @@ class Registrar:
         module_name = self.get_required_field_as_string(self.kb_yaml,'module-name').strip()
         module_description = self.get_required_field_as_string(self.kb_yaml,'module-description').strip()
         version = self.get_required_field_as_string(self.kb_yaml,'module-version').strip()
+
+        # must be a semantic version
+        if not semantic_version.validate(version):
+            raise ValueError('Invalid version string in kbase.yaml - must be in semantic version format.  See http://semver.org')
+
         service_language = self.get_required_field_as_string(self.kb_yaml,'service-language').strip()
         owners = self.get_required_field_as_list(self.kb_yaml,'owners')
 

--- a/lib/biokbase/catalog/version.py
+++ b/lib/biokbase/catalog/version.py
@@ -1,2 +1,2 @@
 # File that simply defines version information
-CATALOG_VERSION = '0.0.8'
+CATALOG_VERSION = '0.0.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pymongo==2.8
 docker-py
 gitpython
 pyyaml
+semantic_version

--- a/test/admin_methods_test.py
+++ b/test/admin_methods_test.py
@@ -150,47 +150,48 @@ class AdminMethodsTest(unittest.TestCase):
         self.assertEqual(info['language'],'python')
 
 
-    def test_active_inactive_setting(self):
+    # Method migrated to core registration test, as this needs a fresh registration to test with NMS
+    # def test_active_inactive_setting(self):
 
-        # next make sure we get an error if we are not an admin
-        params = { 'module_name':"release_history" }
-        with self.assertRaises(ValueError) as e:
-            self.catalog.set_to_active(self.cUtil.user_ctx(),params)
-        self.assertEqual(str(e.exception),
-            'Only Admin users can set a module to be active/inactive.');
-        with self.assertRaises(ValueError) as e:
-            self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
-        self.assertEqual(str(e.exception),
-            'Only Admin users can set a module to be active/inactive.');
+    #     # next make sure we get an error if we are not an admin
+    #     params = { 'module_name':"release_history" }
+    #     with self.assertRaises(ValueError) as e:
+    #         self.catalog.set_to_active(self.cUtil.user_ctx(),params)
+    #     self.assertEqual(str(e.exception),
+    #         'Only Admin users can set a module to be active/inactive.');
+    #     with self.assertRaises(ValueError) as e:
+    #         self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
+    #     self.assertEqual(str(e.exception),
+    #         'Only Admin users can set a module to be active/inactive.');
 
-        # release_history module is active, but it should be fine to set it again
-        self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
-        state = self.catalog.get_module_state(self.cUtil.admin_ctx(),params)[0]
-        self.assertEqual(state['active'],1)
+    #     # release_history module is active, but it should be fine to set it again
+    #     self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
+    #     state = self.catalog.get_module_state(self.cUtil.admin_ctx(),params)[0]
+    #     self.assertEqual(state['active'],1)
 
-        # make it inactive (calling twice should be ok and shouldn't change anything)
-        self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
-        state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
-        self.assertEqual(state['active'],0)
+    #     # make it inactive (calling twice should be ok and shouldn't change anything)
+    #     self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
+    #     state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
+    #     self.assertEqual(state['active'],0)
 
-        self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
-        state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
-        self.assertEqual(state['active'],0)
+    #     self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
+    #     state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
+    #     self.assertEqual(state['active'],0)
 
-        # these still shouldn't work
-        with self.assertRaises(ValueError) as e:
-            self.catalog.set_to_active(self.cUtil.user_ctx(),params)
-        self.assertEqual(str(e.exception),
-            'Only Admin users can set a module to be active/inactive.');
-        with self.assertRaises(ValueError) as e:
-            self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
-        self.assertEqual(str(e.exception),
-            'Only Admin users can set a module to be active/inactive.');
+    #     # these still shouldn't work
+    #     with self.assertRaises(ValueError) as e:
+    #         self.catalog.set_to_active(self.cUtil.user_ctx(),params)
+    #     self.assertEqual(str(e.exception),
+    #         'Only Admin users can set a module to be active/inactive.');
+    #     with self.assertRaises(ValueError) as e:
+    #         self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
+    #     self.assertEqual(str(e.exception),
+    #         'Only Admin users can set a module to be active/inactive.');
 
-        # make it active one more time for kicks
-        self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
-        state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),params)[0]
-        self.assertEqual(state['active'],1)
+    #     # make it active one more time for kicks
+    #     self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
+    #     state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),params)[0]
+    #     self.assertEqual(state['active'],1)
 
 
 

--- a/test/admin_methods_test.py
+++ b/test/admin_methods_test.py
@@ -25,11 +25,15 @@ class AdminMethodsTest(unittest.TestCase):
         self.assertEqual(is_approved,[0,0])
 
         # add somebody fails without admin user
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.approve_developer(self.cUtil.user_ctx(),'alice')
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Only Admin users can approve or revoke developers.');
+        with self.assertRaises(ValueError) as e:
             # should fail if we specified something empty
             self.catalog.approve_developer(self.cUtil.admin_ctx(),' ')
+        self.assertEqual(str(e.exception),
+            'No username provided');
 
         # add some users
         self.catalog.approve_developer(self.cUtil.admin_ctx(),'eve')
@@ -43,15 +47,21 @@ class AdminMethodsTest(unittest.TestCase):
         self.assertEqual(is_approved,[0,1,0,1,1])
 
         # remove some
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             # should fail, only admins can revoke users
             self.catalog.revoke_developer(self.cUtil.user_ctx(),'alice')
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Only Admin users can approve or revoke developers.');
+        with self.assertRaises(ValueError) as e:
             # should fail if we misspelled a name
             self.catalog.revoke_developer(self.cUtil.admin_ctx(),'b0b')
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Cannot revoke "b0b", that developer was not found.');
+        with self.assertRaises(ValueError) as e:
             # should fail if we specified something empty
             self.catalog.revoke_developer(self.cUtil.admin_ctx(),' ')
+        self.assertEqual(str(e.exception),
+            'No username provided');
         self.catalog.revoke_developer(self.cUtil.admin_ctx(),'alice')
 
         # should have truncated list
@@ -62,9 +72,11 @@ class AdminMethodsTest(unittest.TestCase):
         self.assertEqual(is_approved,[0,0,0,1,1])
 
         # should block registration for non-developers
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.register_repo(self.cUtil.user_ctx(),
                 {'git_url':self.cUtil.get_test_repo_1()})
+        self.assertEqual(str(e.exception),
+            'You are not an approved developer.  Contact us to request approval.');
 
         # after the developer is added, should be allowed to start now (give a bogus url so if finishes registration
         # right away with an error
@@ -92,17 +104,21 @@ class AdminMethodsTest(unittest.TestCase):
         self.assertEqual(info['language'],'python')
 
         # next make sure we get an error if we are not an admin
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.migrate_module_to_new_git_url(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Only Admin users can migrate module git urls.');
 
         # if we are an admin, then it should work
         self.catalog.migrate_module_to_new_git_url(self.cUtil.admin_ctx(),params)
 
         # the old record should not be retrievable by that url anymore
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.get_module_info(self.cUtil.anonymous_ctx(),
                 {'module_name':params['module_name'],
                  'git_url':params['current_git_url']})[0]
+        self.assertEqual(str(e.exception),
+            'Operation failed - module/repo is not registered.');
         # but the new url should work
         info = self.catalog.get_module_info(self.cUtil.anonymous_ctx(),
             {'module_name':params['module_name'],
@@ -112,13 +128,17 @@ class AdminMethodsTest(unittest.TestCase):
         self.assertEqual(info['language'],'python')
 
         # things should fail if we just try again
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.migrate_module_to_new_git_url(self.cUtil.admin_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Cannot migrate git_url, no module found with the given name and current url.');
         # or if the new url is not valid
         params['current_git_url'] = params['new_git_url']
         params['new_git_url'] = "http:not_a_url"
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.migrate_module_to_new_git_url(self.cUtil.admin_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'The new git url is not a valid URL.');
 
         # but we should be able to switch back
         params['new_git_url'] = "https://github.com/kbaseIncubator/release_history"
@@ -134,10 +154,14 @@ class AdminMethodsTest(unittest.TestCase):
 
         # next make sure we get an error if we are not an admin
         params = { 'module_name':"release_history" }
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.set_to_active(self.cUtil.user_ctx(),params)
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
+        with self.assertRaises(ValueError) as e:
             self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
 
         # release_history module is active, but it should be fine to set it again
         self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
@@ -154,10 +178,14 @@ class AdminMethodsTest(unittest.TestCase):
         self.assertEqual(state['active'],0)
 
         # these still shouldn't work
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.set_to_active(self.cUtil.user_ctx(),params)
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
+        with self.assertRaises(ValueError) as e:
             self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
 
         # make it active one more time for kicks
         self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
@@ -176,8 +204,10 @@ class AdminMethodsTest(unittest.TestCase):
 
         # throw an error- users should not be able to update state
         params = { 'module_name' : 'registration_in_progress', 'registration_state':'complete' }
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.set_registration_state(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'You do not have permission to modify the registration state of this module/repo.');
 
         # state should still be the same
         state = self.catalog.get_module_state(self.cUtil.user_ctx(),repoSelectionParam)[0]
@@ -192,8 +222,10 @@ class AdminMethodsTest(unittest.TestCase):
 
         # admin cannot set the state to error without an error message
         params = { 'module_name' : 'registration_in_progress', 'registration_state':'error' }
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.set_registration_state(self.cUtil.admin_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Update failed - if state is "error", you must also set an "error_message".');
         state = self.catalog.get_module_state(self.cUtil.user_ctx(),repoSelectionParam)[0]
         self.assertEqual(state['registration'],'complete')
         self.assertEqual(state['error_message'],'')

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -14,7 +14,7 @@ class BasicCatalogTest(unittest.TestCase):
 
 
     def test_version(self):
-        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.8'])
+        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.9'])
 
 
     def test_is_registered(self):

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -194,21 +194,31 @@ class BasicCatalogTest(unittest.TestCase):
         self.assertEqual(state['error_message'],'')
 
         # test various fail cases where a module does not exist
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.get_module_state(self.cUtil.anonymous_ctx(),
             {'module_name':'not_a_module'})
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Operation failed - module/repo is not registered.');
+        with self.assertRaises(ValueError) as e:
             self.catalog.get_module_state(self.cUtil.anonymous_ctx(),
             {'git_url':'not_a_giturl'})
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Operation failed - module/repo is not registered.');
+        with self.assertRaises(ValueError) as e:
             self.catalog.get_module_state(self.cUtil.anonymous_ctx(),
             {})
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Operation failed - module/repo is not registered.');
+        with self.assertRaises(ValueError) as e:
             self.catalog.get_module_state(self.cUtil.anonymous_ctx(),
             {'module_name':'not_a_module','git_url':'https://github.com/kbaseIncubator/registration_in_progress'})
-        with self.assertRaises(ValueError):
+        self.assertEqual(str(e.exception),
+            'Operation failed - module/repo is not registered.');
+        with self.assertRaises(ValueError) as e:
             self.catalog.get_module_state(self.cUtil.anonymous_ctx(),
             {'module_name':'onerepotest','git_url':'not_a_url'})
+        self.assertEqual(str(e.exception),
+            'Operation failed - module/repo is not registered.');
 
 
     def test_get_module_info(self):
@@ -305,31 +315,41 @@ class BasicCatalogTest(unittest.TestCase):
         self.assertEqual(vinfo['narrative_methods'],['send_data'])
 
         # wrong version set
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                 {'module_name':'release_history', 'version':'not_a_Version'})
+        self.assertEqual(str(e.exception),
+            'invalid version selection, valid versions are: "dev" | "beta" | "release"');
         # test wrong git commit hash
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history', 'version':'release',
                     'git_commit_hash':'b06c5f9daf603a4d206071787c3f6184000bf128'})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
         # test wrong timestamp
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history', 'version':'release',
                     'timestamp':1445024094055})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
         # right git commit, wrong timestamp
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history', 'version':'release',
                     'git_commit_hash':'b06c5f9daf603a4d206071787c3f6184000bf128',
                     'timestamp':1445024094055})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
         # right timestamp, wrong git commit hash
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history', 'version':'release',
                     'git_commit_hash':'b843888e962642d665a3b0bd701ee630c01835e6',
                     'timestamp':1445022818884})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
 
         #########
         # now we test with a timestamp retrieval, first from one of the currents
@@ -350,10 +370,12 @@ class BasicCatalogTest(unittest.TestCase):
         self.assertEqual(vinfo['version'],"0.0.3")
         self.assertEqual(vinfo['narrative_methods'],['send_data'])
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history', 'timestamp':1445022818884,
                     'git_commit_hash':"49dc505febb8f4cccb2078c51ded0de3320534d7"})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
 
         # now with something in the history
         vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
@@ -374,15 +396,19 @@ class BasicCatalogTest(unittest.TestCase):
         self.assertEqual(vinfo['narrative_methods'],['send_data'])
 
         # test wrong timestamp
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history',
                     'timestamp':1445024094078})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history', 'timestamp':1445022818000, 
                     'git_commit_hash':"49dc505febb8f4cccb2078c51ded0de3320534d7"})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
 
 
 
@@ -406,10 +432,12 @@ class BasicCatalogTest(unittest.TestCase):
         self.assertEqual(vinfo['narrative_methods'],['send_data'])
 
         # test wrong git commit hash
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as e:
             vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
                     {'module_name':'release_history', 
                     'git_commit_hash':'b06c5f9daf603a4d202071787c3f6184000bf128'})[0]
+        self.assertEqual(str(e.exception),
+            'No version found that matches all your criteria!');
 
 
 

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -14,7 +14,7 @@ class BasicCatalogTest(unittest.TestCase):
 
 
     def test_version(self):
-        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.7'])
+        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['0.0.8'])
 
 
     def test_is_registered(self):

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -77,7 +77,9 @@ class CatalogTestUtil:
             'docker-registry-host':self.test_cfg['docker-registry-host'],
             'nms-url':self.test_cfg['nms-url'],
             'nms-admin-user':self.test_cfg['nms-admin-user'],
-            'nms-admin-psswd':self.test_cfg['nms-admin-psswd']
+            'nms-admin-psswd':self.test_cfg['nms-admin-psswd'],
+            'ref-data-base':self.test_cfg['ref-data-base'],
+            'kbase-endpoint':self.test_cfg['kbase-endpoint']
         }
 
 

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -533,28 +533,25 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertTrue(foundMeth,'Make sure we found the method in NMS')
 
         # make it inactive (calling twice should be ok and shouldn't change anything)
+        self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
+        state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
+        self.assertEqual(state['active'],0)
+        method_list = self.nms.list_methods({'tag':'dev'})
+        foundMeth = False
+        for meth in method_list:
+            if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
+                foundMeth = True
+        self.assertFalse(foundMeth,'Make sure we did not find the method in NMS')
 
-        # SKIP INACTIVATE TESTS UNTIL WE HAVE AN ACTIVATE METHOD IN NMS
-
-        #self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
-        #state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
-        #self.assertEqual(state['active'],0)
-        #method_list = self.nms.list_methods({'tag':'dev'})
-        #foundMeth = False
-        #for meth in method_list:
-        #    if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
-        #        foundMeth = True
-        #self.assertFalse(foundMeth,'Make sure we did not find the method in NMS')
-
-        #self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
-        #state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
-        #self.assertEqual(state['active'],0)
-        #method_list = self.nms.list_methods({'tag':'dev'})
-        #foundMeth = False
-        #for meth in method_list:
-        #    if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
-        #        foundMeth = True
-        #self.assertFalse(foundMeth,'Make sure we did not find the method in NMS')
+        self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
+        state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
+        self.assertEqual(state['active'],0)
+        method_list = self.nms.list_methods({'tag':'dev'})
+        foundMeth = False
+        for meth in method_list:
+            if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
+                foundMeth = True
+        self.assertFalse(foundMeth,'Make sure we did not find the method in NMS again')
 
 
         # these still shouldn't work

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -261,6 +261,7 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(info['release']['narrative_methods'],['test_method_1'])
         self.assertEqual(info['release']['version'],'0.0.1')
         self.assertEqual(info['release']['timestamp'],timestamp)
+        self.assertTrue(info['release']['release_timestamp']>info['release']['timestamp']);
         self.assertEqual(info['release']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
         versions = self.catalog.list_released_module_versions(self.cUtil.anonymous_ctx(),{'module_name':module_name})[0]

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -314,7 +314,7 @@ class CoreRegistrationTest(unittest.TestCase):
                 break
             self.assertTrue(time()-start < timeout, 'simple registration build 2 exceeded timeout of '+str(timeout)+'s')
         self.assertEqual(state['registration'],'complete')
-        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),timestamp2)
+        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),registration_id2)
         self.assertTrue(log is not None)
 
         info = self.catalog.get_module_info(self.cUtil.anonymous_ctx(),{'module_name':module_name})[0]
@@ -340,17 +340,90 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(info['release']['timestamp'],timestamp)
         self.assertEqual(info['release']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash)
 
-
         # assert fail on request release because you can't update release version if they are the same
         with self.assertRaises(ValueError) as e:
-            self.catalog.request_release(self.cUtil.user_ctx(),{'module_name':info['module_name']});
+            self.catalog.request_release(self.cUtil.user_ctx(),{'module_name':info['module_name']})
         self.assertEqual(str(e.exception),
-            'Cannot request release - beta version is identical to released version.');
-
-        # migrate dev to beta, release it.  Register new version, but with same version number.  Try to update, should get a semantic version not updated error
+            'Cannot request release - beta version is identical to released version.')
 
 
+        # 10) migrate dev to beta again, release it.  Should work. 
+        self.catalog.push_dev_to_beta(self.cUtil.user_ctx(),{'module_name':module_name})
+        self.catalog.request_release(self.cUtil.user_ctx(),{'module_name':info['module_name']})
+        self.catalog.review_release_request(self.cUtil.admin_ctx(),
+                        {'module_name':module_name, 'decision':'approved'})
+        info = self.catalog.get_module_info(self.cUtil.anonymous_ctx(),{'module_name':module_name})[0]
+        self.assertEqual(info['release']['git_commit_hash'],githash2)
+        self.assertEqual(info['release']['git_commit_message'],'added new method\n')
+        self.assertEqual(info['release']['narrative_methods'],['test_method_1','test_method_2'])
+        self.assertEqual(info['release']['version'],'0.0.2')
+        self.assertEqual(info['release']['timestamp'],timestamp2)
+        self.assertTrue(info['release']['release_timestamp']>timestamp2)
+        self.assertEqual(info['release']['docker_img_name'].split('/')[1],'kbase:' + module_name.lower()+'.'+githash2)
 
+        # 11) register new version, but with bad version number.  Should fail.  Needs to be a semantic version
+        githash3 = '9908c20cd5d275190490d7b852f22e5da73f9260' # branch simple_good_repo
+        registration_id3 = self.catalog.register_repo(self.cUtil.user_ctx(),
+            {'git_url':giturl, 'git_commit_hash':githash3})[0]
+        timestamp3 = int(registration_id3.split('_')[0])
+        start = time()
+        timeout = 60 #seconds
+        while True:
+            state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),{'git_url':giturl})[0]
+            if state['registration'] in ['complete','error']:
+                break
+            self.assertTrue(time()-start < timeout, 'simple registration build 3 exceeded timeout of '+str(timeout)+'s')
+        self.assertEqual(state['registration'],'error')
+        log = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),{'registration_id':registration_id3})
+        self.assertTrue(log is not None)
+        self.assertTrue('must be in semantic version format' in log[0]['error_message'])
+
+        #Register new version, but with same version number as in the release so should fail
+        githash4 = '6add31077a4982d6c8a5bc161915d30bfec3fe0c' # branch simple_good_repo
+        registration_id4 = self.catalog.register_repo(self.cUtil.user_ctx(),
+            {'git_url':giturl, 'git_commit_hash':githash4})[0]
+        timestamp4 = int(registration_id4.split('_')[0])
+        start = time()
+        timeout = 60 #seconds
+        while True:
+            state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),{'git_url':giturl})[0]
+            if state['registration'] in ['complete','error']:
+                break
+            self.assertTrue(time()-start < timeout, 'simple registration build 4 exceeded timeout of '+str(timeout)+'s')
+        self.assertEqual(state['registration'],'complete')
+        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),registration_id4)
+        self.assertTrue(log is not None)
+
+        self.catalog.push_dev_to_beta(self.cUtil.user_ctx(),{'module_name':module_name})
+        with self.assertRaises(ValueError) as e:
+            self.catalog.request_release(self.cUtil.user_ctx(),{'module_name':info['module_name']})
+        self.assertEqual(str(e.exception),
+            'Cannot request release - beta version has same version number to released version.')
+
+        # Finally, try once again but with a version number that is less than the current release version
+        githash5 = '7627fa25e75515316407577e5578c2cb120ca40f' # branch simple_good_repo
+        registration_id5 = self.catalog.register_repo(self.cUtil.user_ctx(),
+            {'git_url':giturl, 'git_commit_hash':githash5})[0]
+        timestamp5 = int(registration_id5.split('_')[0])
+        start = time()
+        timeout = 60 #seconds
+        while True:
+            state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),{'git_url':giturl})[0]
+            if state['registration'] in ['complete','error']:
+                break
+            self.assertTrue(time()-start < timeout, 'simple registration build 5 exceeded timeout of '+str(timeout)+'s')
+        self.assertEqual(state['registration'],'complete')
+        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),registration_id5)
+        self.assertTrue(log is not None)
+
+        self.catalog.push_dev_to_beta(self.cUtil.user_ctx(),{'module_name':module_name})
+        with self.assertRaises(ValueError) as e:
+            self.catalog.request_release(self.cUtil.user_ctx(),{'module_name':info['module_name']})
+        self.assertEqual(str(e.exception),
+            'Cannot request release - beta version semantic version must be greater than the released version semantic version, as determined by http://semver.org')
+
+
+        # TODO test method store to be sure we can get old method specs by commit hash
 
 
 
@@ -380,7 +453,7 @@ class CoreRegistrationTest(unittest.TestCase):
         # (1) register the test repo
         giturl = self.cUtil.get_test_repo_1()
         githash = 'ca3d7ae05af24cd1c5d21ec9e0e4c52c52695300' # branch fail_method_spec_1
-        timestamp = self.catalog.register_repo(self.cUtil.user_ctx(),
+        registration_id = self.catalog.register_repo(self.cUtil.user_ctx(),
             {'git_url':giturl, 'git_commit_hash':githash})[0]
 
         # (2) check state until error or complete, must be error, and make sure this was relatively fast
@@ -393,13 +466,13 @@ class CoreRegistrationTest(unittest.TestCase):
             self.assertTrue(time()-start < timeout, 'simple registration build exceeded timeout of '+str(timeout)+'s')
         self.assertEqual(state['registration'],'error')
         self.assertTrue('Invalid narrative method specification (test_method_2)' in state['error_message'])
-        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),timestamp)[0]
+        log = self.catalog.get_build_log(self.cUtil.anonymous_ctx(),registration_id)[0]
         self.assertTrue(log is not None)
         self.assertTrue('param0_that_is_not_defined_in_yaml' in log)
 
 
 
-    def test_remove_module(self):
+    def test_active_inactive_remove_module(self):
 
         # we cannot delete modules unles we are an admin user
         with self.assertRaises(ValueError) as e:
@@ -410,7 +483,7 @@ class CoreRegistrationTest(unittest.TestCase):
 
         method_list = self.nms.list_methods({'tag':'dev'})
 
-        # this should work: register a repo, make sure it appears, delete it, and it should be gone
+        # this should work: register a repo, make sure it appears
         giturl = self.cUtil.get_test_repo_2()
         githash = 'a2b66a4668548bbabc54ee937ac91f9237874a96' # branch simple_good_repo2 
 
@@ -433,6 +506,78 @@ class CoreRegistrationTest(unittest.TestCase):
             if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
                 foundMeth = True
         self.assertTrue(foundMeth,'Make sure we found the method in NMS')
+
+
+        # next make sure we get an error if we are not an admin if we try to make the repo active or inactive
+        params = { 'git_url':giturl }
+        with self.assertRaises(ValueError) as e:
+            self.catalog.set_to_active(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
+        with self.assertRaises(ValueError) as e:
+            self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
+
+        # module should start as active, but it should be fine to set it again
+        state = self.catalog.get_module_state(self.cUtil.admin_ctx(),params)[0]
+        self.assertEqual(state['active'],1)
+        self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
+        state = self.catalog.get_module_state(self.cUtil.admin_ctx(),params)[0]
+        self.assertEqual(state['active'],1)
+        method_list = self.nms.list_methods({'tag':'dev'})
+        foundMeth = False
+        for meth in method_list:
+            if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
+                foundMeth = True
+        self.assertTrue(foundMeth,'Make sure we found the method in NMS')
+
+        # make it inactive (calling twice should be ok and shouldn't change anything)
+
+        # SKIP INACTIVATE TESTS UNTIL WE HAVE AN ACTIVATE METHOD IN NMS
+
+        #self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
+        #state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
+        #self.assertEqual(state['active'],0)
+        #method_list = self.nms.list_methods({'tag':'dev'})
+        #foundMeth = False
+        #for meth in method_list:
+        #    if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
+        #        foundMeth = True
+        #self.assertFalse(foundMeth,'Make sure we did not find the method in NMS')
+
+        #self.catalog.set_to_inactive(self.cUtil.admin_ctx(),params)
+        #state = self.catalog.get_module_state(self.cUtil.user_ctx(),params)[0]
+        #self.assertEqual(state['active'],0)
+        #method_list = self.nms.list_methods({'tag':'dev'})
+        #foundMeth = False
+        #for meth in method_list:
+        #    if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
+        #        foundMeth = True
+        #self.assertFalse(foundMeth,'Make sure we did not find the method in NMS')
+
+
+        # these still shouldn't work
+        with self.assertRaises(ValueError) as e:
+            self.catalog.set_to_active(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
+        with self.assertRaises(ValueError) as e:
+            self.catalog.set_to_inactive(self.cUtil.user_ctx(),params)
+        self.assertEqual(str(e.exception),
+            'Only Admin users can set a module to be active/inactive.');
+
+        # make it active one more time and make sure the method specs reappear
+        self.catalog.set_to_active(self.cUtil.admin_ctx(),params)
+        state = self.catalog.get_module_state(self.cUtil.anonymous_ctx(),params)[0]
+        self.assertEqual(state['active'],1)
+        method_list = self.nms.list_methods({'tag':'dev'})
+        foundMeth = False
+        for meth in method_list:
+            if meth['id']=='CatalogTestModule2/test_method_1' and meth['namespace']=='CatalogTestModule2':
+                foundMeth = True
+        self.assertTrue(foundMeth,'Make sure we found the method in NMS after reactivation')
+
 
         # delete it.
         self.catalog.delete_module(self.cUtil.admin_ctx(),

--- a/test/initial_mongo_state/modules/pending_second_release.json
+++ b/test/initial_mongo_state/modules/pending_second_release.json
@@ -51,6 +51,7 @@
         },
         "release" : {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
+            "release_timestamp" : 1445022858884,
             "timestamp" : 1445022818884,
             "registration_id" : "1445022818884_4212",
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:pending_second_release.49dc505febb8f4cccb2078c58ded0de3320534d7",

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -21,5 +21,9 @@ echo '\nstarting tests'
 
 export PYTHONPATH=pylib:$PYTHONPATH
 python -m unittest discover -p "*_test.py"
+TEST_RETURN_CODE=$?
+echo "unit tests returned with error code=${TEST_RETURN_CODE}"
 
 kill -9 $NMS_PID
+
+exit ${TEST_RETURN_CODE}

--- a/test/test.cfg.example
+++ b/test/test.cfg.example
@@ -16,6 +16,7 @@ test-user-2 = wstester2
 
 # Example repos for testing
 test-module-repo-1 = https://github.com/kbaseIncubator/catalog_test_module
+test-module-repo-2 = https://github.com/kbaseIncubator/catalog_test_module.git
 
 # host where mongo lives, e.g. localhost:27017, for tests there should be not authentication required
 mongodb-host = localhost:27017

--- a/test/test.cfg.example
+++ b/test/test.cfg.example
@@ -36,6 +36,9 @@ nms-url = http://localhost:7125
 nms-admin-user = wstester4
 nms-admin-psswd = 
 
+# configs for reference data
+ref-data-base = /kb/data
+kbase-endpoint = https://ci.kbase.us/services
 
 
 [NarrativeMethodStore]


### PR DESCRIPTION
This PR enforces that module versions must be a valid semantic version (as is generated by the SDK be default), and that on release that semantic version must increase.  Previously the version was simply any string.

Also has several bugfixes, and explicitly now tracks the time that a module is approved for release, so we can sort modules by release date.

Depends on a small update to NMS:
https://github.com/kbase/narrative_method_store/pull/23

Still need to add catalog version bump and small commit once that NMS pr is in.
