### PR TITLE
Two changes (in exec-stats and in registration). See description.

### DIFF
--- a/catalog.spec
+++ b/catalog.spec
@@ -138,6 +138,17 @@ module Catalog {
     funcdef list_favorite_counts(ListFavoriteCounts params) returns (list<FavoriteCount> counts);
 
 
+    typedef structure {
+        int start_line;
+        int end_line;
+    } FunctionPlace;
+
+    typedef structure {
+        string sdk_version;
+        string sdk_git_commit;
+        string impl_file_path;
+        mapping<string, FunctionPlace> function_places;
+    } CompilationReport;
 
     /*
         data_folder - optional field representing unique module name (like <module_name> transformed to
@@ -160,6 +171,7 @@ module Catalog {
         string docker_img_name;
         string data_folder;
         string data_version;
+        CompilationReport compilation_report;
     } ModuleVersionInfo;
 
     typedef structure {
@@ -382,9 +394,9 @@ module Catalog {
             original execution was started through API call without app ID defined),
         time_range - one of supported time ranges (currently it could be either '*' for all time
             or ISO-encoded week like "2016-W01")
-        avg_queue_time - average time difference between exec_start_time and creation_time moments
+        total_queue_time - summarized time difference between exec_start_time and creation_time moments
             defined in seconds since Epoch (POSIX),
-        avg_exec_time - average time difference between finish_time and exec_start_time moments 
+        total_exec_time - summarized time difference between finish_time and exec_start_time moments 
             defined in seconds since Epoch (POSIX).
     */
     typedef structure {
@@ -392,8 +404,8 @@ module Catalog {
         string time_range;
         int number_of_calls;
         int number_of_errors;
-        float avg_queue_time;
-        float avg_exec_time;
+        float total_queue_time;
+        float total_exec_time;
     } ExecAggrStats;
 
     funcdef get_exec_aggr_stats(GetExecAggrStatsParams params) returns (list<ExecAggrStats>);

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -1268,6 +1268,15 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
 
 </pre>
 
@@ -1299,6 +1308,15 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
 
 
 =end text
@@ -1387,6 +1405,15 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
 
 </pre>
 
@@ -1412,6 +1439,15 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
 
 
 =end text
@@ -1497,6 +1533,15 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
 
 </pre>
 
@@ -1519,6 +1564,15 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
 
 
 =end text
@@ -2865,8 +2919,8 @@ ExecAggrStats is a reference to a hash where the following keys are defined:
 	time_range has a value which is a string
 	number_of_calls has a value which is an int
 	number_of_errors has a value which is an int
-	avg_queue_time has a value which is a float
-	avg_exec_time has a value which is a float
+	total_queue_time has a value which is a float
+	total_exec_time has a value which is a float
 
 </pre>
 
@@ -2885,8 +2939,8 @@ ExecAggrStats is a reference to a hash where the following keys are defined:
 	time_range has a value which is a string
 	number_of_calls has a value which is an int
 	number_of_errors has a value which is an int
-	avg_queue_time has a value which is a float
-	avg_exec_time has a value which is a float
+	total_queue_time has a value which is a float
+	total_exec_time has a value which is a float
 
 
 =end text
@@ -3403,6 +3457,74 @@ count has a value which is an int
 
 
 
+=head2 FunctionPlace
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+start_line has a value which is an int
+end_line has a value which is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+start_line has a value which is an int
+end_line has a value which is an int
+
+
+=end text
+
+=back
+
+
+
+=head2 CompilationReport
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+sdk_version has a value which is a string
+sdk_git_commit has a value which is a string
+impl_file_path has a value which is a string
+function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+sdk_version has a value which is a string
+sdk_git_commit has a value which is a string
+impl_file_path has a value which is a string
+function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+
+
+=end text
+
+=back
+
+
+
 =head2 ModuleVersionInfo
 
 =over 4
@@ -3437,6 +3559,7 @@ narrative_method_ids has a value which is a reference to a list where each eleme
 docker_img_name has a value which is a string
 data_folder has a value which is a string
 data_version has a value which is a string
+compilation_report has a value which is a Catalog.CompilationReport
 
 </pre>
 
@@ -3454,6 +3577,7 @@ narrative_method_ids has a value which is a reference to a list where each eleme
 docker_img_name has a value which is a string
 data_folder has a value which is a string
 data_version has a value which is a string
+compilation_report has a value which is a Catalog.CompilationReport
 
 
 =end text
@@ -4011,9 +4135,9 @@ full_app_id - optional fully qualified method-spec id including module_name pref
     original execution was started through API call without app ID defined),
 time_range - one of supported time ranges (currently it could be either '*' for all time
     or ISO-encoded week like "2016-W01")
-avg_queue_time - average time difference between exec_start_time and creation_time moments
+total_queue_time - summarized time difference between exec_start_time and creation_time moments
     defined in seconds since Epoch (POSIX),
-avg_exec_time - average time difference between finish_time and exec_start_time moments 
+total_exec_time - summarized time difference between finish_time and exec_start_time moments 
     defined in seconds since Epoch (POSIX).
 
 
@@ -4027,8 +4151,8 @@ full_app_id has a value which is a string
 time_range has a value which is a string
 number_of_calls has a value which is an int
 number_of_errors has a value which is an int
-avg_queue_time has a value which is a float
-avg_exec_time has a value which is a float
+total_queue_time has a value which is a float
+total_exec_time has a value which is a float
 
 </pre>
 
@@ -4041,8 +4165,8 @@ full_app_id has a value which is a string
 time_range has a value which is a string
 number_of_calls has a value which is an int
 number_of_errors has a value which is an int
-avg_queue_time has a value which is a float
-avg_exec_time has a value which is a float
+total_queue_time has a value which is a float
+total_exec_time has a value which is a float
 
 
 =end text

--- a/lib/java/us/kbase/catalog/CompilationReport.java
+++ b/lib/java/us/kbase/catalog/CompilationReport.java
@@ -1,0 +1,114 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: CompilationReport</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "sdk_version",
+    "sdk_git_commit",
+    "impl_file_path",
+    "function_places"
+})
+public class CompilationReport {
+
+    @JsonProperty("sdk_version")
+    private java.lang.String sdkVersion;
+    @JsonProperty("sdk_git_commit")
+    private java.lang.String sdkGitCommit;
+    @JsonProperty("impl_file_path")
+    private java.lang.String implFilePath;
+    @JsonProperty("function_places")
+    private Map<String, FunctionPlace> functionPlaces;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("sdk_version")
+    public java.lang.String getSdkVersion() {
+        return sdkVersion;
+    }
+
+    @JsonProperty("sdk_version")
+    public void setSdkVersion(java.lang.String sdkVersion) {
+        this.sdkVersion = sdkVersion;
+    }
+
+    public CompilationReport withSdkVersion(java.lang.String sdkVersion) {
+        this.sdkVersion = sdkVersion;
+        return this;
+    }
+
+    @JsonProperty("sdk_git_commit")
+    public java.lang.String getSdkGitCommit() {
+        return sdkGitCommit;
+    }
+
+    @JsonProperty("sdk_git_commit")
+    public void setSdkGitCommit(java.lang.String sdkGitCommit) {
+        this.sdkGitCommit = sdkGitCommit;
+    }
+
+    public CompilationReport withSdkGitCommit(java.lang.String sdkGitCommit) {
+        this.sdkGitCommit = sdkGitCommit;
+        return this;
+    }
+
+    @JsonProperty("impl_file_path")
+    public java.lang.String getImplFilePath() {
+        return implFilePath;
+    }
+
+    @JsonProperty("impl_file_path")
+    public void setImplFilePath(java.lang.String implFilePath) {
+        this.implFilePath = implFilePath;
+    }
+
+    public CompilationReport withImplFilePath(java.lang.String implFilePath) {
+        this.implFilePath = implFilePath;
+        return this;
+    }
+
+    @JsonProperty("function_places")
+    public Map<String, FunctionPlace> getFunctionPlaces() {
+        return functionPlaces;
+    }
+
+    @JsonProperty("function_places")
+    public void setFunctionPlaces(Map<String, FunctionPlace> functionPlaces) {
+        this.functionPlaces = functionPlaces;
+    }
+
+    public CompilationReport withFunctionPlaces(Map<String, FunctionPlace> functionPlaces) {
+        this.functionPlaces = functionPlaces;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((("CompilationReport"+" [sdkVersion=")+ sdkVersion)+", sdkGitCommit=")+ sdkGitCommit)+", implFilePath=")+ implFilePath)+", functionPlaces=")+ functionPlaces)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/ExecAggrStats.java
+++ b/lib/java/us/kbase/catalog/ExecAggrStats.java
@@ -19,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *     original execution was started through API call without app ID defined),
  * time_range - one of supported time ranges (currently it could be either '*' for all time
  *     or ISO-encoded week like "2016-W01")
- * avg_queue_time - average time difference between exec_start_time and creation_time moments
+ * total_queue_time - summarized time difference between exec_start_time and creation_time moments
  *     defined in seconds since Epoch (POSIX),
- * avg_exec_time - average time difference between finish_time and exec_start_time moments 
+ * total_exec_time - summarized time difference between finish_time and exec_start_time moments 
  *     defined in seconds since Epoch (POSIX).
  * </pre>
  * 
@@ -33,8 +33,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "time_range",
     "number_of_calls",
     "number_of_errors",
-    "avg_queue_time",
-    "avg_exec_time"
+    "total_queue_time",
+    "total_exec_time"
 })
 public class ExecAggrStats {
 
@@ -46,10 +46,10 @@ public class ExecAggrStats {
     private Long numberOfCalls;
     @JsonProperty("number_of_errors")
     private Long numberOfErrors;
-    @JsonProperty("avg_queue_time")
-    private Double avgQueueTime;
-    @JsonProperty("avg_exec_time")
-    private Double avgExecTime;
+    @JsonProperty("total_queue_time")
+    private Double totalQueueTime;
+    @JsonProperty("total_exec_time")
+    private Double totalExecTime;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @JsonProperty("full_app_id")
@@ -112,33 +112,33 @@ public class ExecAggrStats {
         return this;
     }
 
-    @JsonProperty("avg_queue_time")
-    public Double getAvgQueueTime() {
-        return avgQueueTime;
+    @JsonProperty("total_queue_time")
+    public Double getTotalQueueTime() {
+        return totalQueueTime;
     }
 
-    @JsonProperty("avg_queue_time")
-    public void setAvgQueueTime(Double avgQueueTime) {
-        this.avgQueueTime = avgQueueTime;
+    @JsonProperty("total_queue_time")
+    public void setTotalQueueTime(Double totalQueueTime) {
+        this.totalQueueTime = totalQueueTime;
     }
 
-    public ExecAggrStats withAvgQueueTime(Double avgQueueTime) {
-        this.avgQueueTime = avgQueueTime;
+    public ExecAggrStats withTotalQueueTime(Double totalQueueTime) {
+        this.totalQueueTime = totalQueueTime;
         return this;
     }
 
-    @JsonProperty("avg_exec_time")
-    public Double getAvgExecTime() {
-        return avgExecTime;
+    @JsonProperty("total_exec_time")
+    public Double getTotalExecTime() {
+        return totalExecTime;
     }
 
-    @JsonProperty("avg_exec_time")
-    public void setAvgExecTime(Double avgExecTime) {
-        this.avgExecTime = avgExecTime;
+    @JsonProperty("total_exec_time")
+    public void setTotalExecTime(Double totalExecTime) {
+        this.totalExecTime = totalExecTime;
     }
 
-    public ExecAggrStats withAvgExecTime(Double avgExecTime) {
-        this.avgExecTime = avgExecTime;
+    public ExecAggrStats withTotalExecTime(Double totalExecTime) {
+        this.totalExecTime = totalExecTime;
         return this;
     }
 
@@ -154,7 +154,7 @@ public class ExecAggrStats {
 
     @Override
     public String toString() {
-        return ((((((((((((((("ExecAggrStats"+" [fullAppId=")+ fullAppId)+", timeRange=")+ timeRange)+", numberOfCalls=")+ numberOfCalls)+", numberOfErrors=")+ numberOfErrors)+", avgQueueTime=")+ avgQueueTime)+", avgExecTime=")+ avgExecTime)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((("ExecAggrStats"+" [fullAppId=")+ fullAppId)+", timeRange=")+ timeRange)+", numberOfCalls=")+ numberOfCalls)+", numberOfErrors=")+ numberOfErrors)+", totalQueueTime=")+ totalQueueTime)+", totalExecTime=")+ totalExecTime)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/FunctionPlace.java
+++ b/lib/java/us/kbase/catalog/FunctionPlace.java
@@ -1,0 +1,78 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: FunctionPlace</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "start_line",
+    "end_line"
+})
+public class FunctionPlace {
+
+    @JsonProperty("start_line")
+    private Long startLine;
+    @JsonProperty("end_line")
+    private Long endLine;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("start_line")
+    public Long getStartLine() {
+        return startLine;
+    }
+
+    @JsonProperty("start_line")
+    public void setStartLine(Long startLine) {
+        this.startLine = startLine;
+    }
+
+    public FunctionPlace withStartLine(Long startLine) {
+        this.startLine = startLine;
+        return this;
+    }
+
+    @JsonProperty("end_line")
+    public Long getEndLine() {
+        return endLine;
+    }
+
+    @JsonProperty("end_line")
+    public void setEndLine(Long endLine) {
+        this.endLine = endLine;
+    }
+
+    public FunctionPlace withEndLine(Long endLine) {
+        this.endLine = endLine;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("FunctionPlace"+" [startLine=")+ startLine)+", endLine=")+ endLine)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/ModuleVersionInfo.java
+++ b/lib/java/us/kbase/catalog/ModuleVersionInfo.java
@@ -38,7 +38,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "narrative_method_ids",
     "docker_img_name",
     "data_folder",
-    "data_version"
+    "data_version",
+    "compilation_report"
 })
 public class ModuleVersionInfo {
 
@@ -60,6 +61,13 @@ public class ModuleVersionInfo {
     private java.lang.String dataFolder;
     @JsonProperty("data_version")
     private java.lang.String dataVersion;
+    /**
+     * <p>Original spec-file type: CompilationReport</p>
+     * 
+     * 
+     */
+    @JsonProperty("compilation_report")
+    private CompilationReport compilationReport;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("timestamp")
@@ -197,6 +205,31 @@ public class ModuleVersionInfo {
         return this;
     }
 
+    /**
+     * <p>Original spec-file type: CompilationReport</p>
+     * 
+     * 
+     */
+    @JsonProperty("compilation_report")
+    public CompilationReport getCompilationReport() {
+        return compilationReport;
+    }
+
+    /**
+     * <p>Original spec-file type: CompilationReport</p>
+     * 
+     * 
+     */
+    @JsonProperty("compilation_report")
+    public void setCompilationReport(CompilationReport compilationReport) {
+        this.compilationReport = compilationReport;
+    }
+
+    public ModuleVersionInfo withCompilationReport(CompilationReport compilationReport) {
+        this.compilationReport = compilationReport;
+        return this;
+    }
+
     @JsonAnyGetter
     public Map<java.lang.String, Object> getAdditionalProperties() {
         return this.additionalProperties;
@@ -209,7 +242,7 @@ public class ModuleVersionInfo {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((("ModuleVersionInfo"+" [timestamp=")+ timestamp)+", registrationId=")+ registrationId)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", gitCommitMessage=")+ gitCommitMessage)+", narrativeMethodIds=")+ narrativeMethodIds)+", dockerImgName=")+ dockerImgName)+", dataFolder=")+ dataFolder)+", dataVersion=")+ dataVersion)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((("ModuleVersionInfo"+" [timestamp=")+ timestamp)+", registrationId=")+ registrationId)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", gitCommitMessage=")+ gitCommitMessage)+", narrativeMethodIds=")+ narrativeMethodIds)+", dockerImgName=")+ dockerImgName)+", dataFolder=")+ dataFolder)+", dataVersion=")+ dataVersion)+", compilationReport=")+ compilationReport)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }


### PR DESCRIPTION
Avg* fields were renamed to Total* in aggregated exec-stats (fields should be renamed automatically without need to wipe db); 
Compilation report parsing was added in repo registration (possible errors don't stop registration process).