### PR TITLE
Initial support of dynamic services and semantic versioning lookup

### DIFF
--- a/catalog.spec
+++ b/catalog.spec
@@ -86,7 +86,6 @@ module Catalog {
     typedef structure {
         string module_name;
         string git_url;
-
     } BasicModuleInfo;
     /*
     To Add:
@@ -216,6 +215,43 @@ module Catalog {
     funcdef get_version_info(SelectModuleVersionParams params) returns (ModuleVersionInfo version);
 
     funcdef list_released_module_versions(SelectOneModuleParams params) returns (list<ModuleVersionInfo> versions);
+
+
+
+
+    /*  DYNAMIC SERVICES SUPPORT Methods */
+
+    typedef structure {
+        string module_name;
+        string version;
+        string git_commit_hash;
+    } BasicModuleVersionInfo;
+
+    /*
+        module_name - required for module lookup
+        lookup - a lookup string, if empty will get the latest released module
+                    1) version tag = dev | beta | release
+                    2) semantic version match identifiier
+                    not supported yet: 3) exact commit hash
+                    not supported yet: 4) exact timestamp
+        only_service_versions - 1/0, default is 1
+    */
+    typedef structure {
+        string module_name;
+        string lookup;
+        boolean only_service_versions;
+    } ModuleVersionLookupParams;
+
+    funcdef module_version_lookup(ModuleVersionLookupParams selection) returns (BasicModuleVersionInfo);
+
+
+    typedef structure {
+        boolean all_versions;
+    } ListServiceModuleParams;
+    funcdef list_service_modules() returns (list<BasicModuleVersionInfo> service_modules);
+
+
+    /*  End Dynamic Services Support Methods */
 
 
     typedef structure {

--- a/catalog.spec
+++ b/catalog.spec
@@ -166,6 +166,7 @@ module Catalog {
         string version;
         string git_commit_hash;
         string git_commit_message;
+        boolean dynamic_service;
         list<string> narrative_method_ids;
         string docker_img_name;
         string data_folder;

--- a/catalog.spec
+++ b/catalog.spec
@@ -244,11 +244,15 @@ module Catalog {
 
     funcdef module_version_lookup(ModuleVersionLookupParams selection) returns (BasicModuleVersionInfo);
 
-
+    /*
+        tag = dev | beta | release
+        if tag is not set, all release versions are returned
+    */
     typedef structure {
-        boolean all_versions;
+        string tag;
     } ListServiceModuleParams;
-    funcdef list_service_modules() returns (list<BasicModuleVersionInfo> service_modules);
+
+    funcdef list_service_modules(ListServiceModuleParams filter) returns (list<BasicModuleVersionInfo> service_modules);
 
 
     /*  End Dynamic Services Support Methods */

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -1266,11 +1266,13 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
 	narrative_method_ids has a value which is a reference to a list where each element is a string
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
 	compilation_report has a value which is a Catalog.CompilationReport
+boolean is an int
 CompilationReport is a reference to a hash where the following keys are defined:
 	sdk_version has a value which is a string
 	sdk_git_commit has a value which is a string
@@ -1306,11 +1308,13 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
 	narrative_method_ids has a value which is a reference to a list where each element is a string
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
 	compilation_report has a value which is a Catalog.CompilationReport
+boolean is an int
 CompilationReport is a reference to a hash where the following keys are defined:
 	sdk_version has a value which is a string
 	sdk_git_commit has a value which is a string
@@ -1403,11 +1407,13 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
 	narrative_method_ids has a value which is a reference to a list where each element is a string
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
 	compilation_report has a value which is a Catalog.CompilationReport
+boolean is an int
 CompilationReport is a reference to a hash where the following keys are defined:
 	sdk_version has a value which is a string
 	sdk_git_commit has a value which is a string
@@ -1437,11 +1443,13 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
 	narrative_method_ids has a value which is a reference to a list where each element is a string
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
 	compilation_report has a value which is a Catalog.CompilationReport
+boolean is an int
 CompilationReport is a reference to a hash where the following keys are defined:
 	sdk_version has a value which is a string
 	sdk_git_commit has a value which is a string
@@ -1531,11 +1539,13 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
 	narrative_method_ids has a value which is a reference to a list where each element is a string
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
 	compilation_report has a value which is a Catalog.CompilationReport
+boolean is an int
 CompilationReport is a reference to a hash where the following keys are defined:
 	sdk_version has a value which is a string
 	sdk_git_commit has a value which is a string
@@ -1562,11 +1572,13 @@ ModuleVersionInfo is a reference to a hash where the following keys are defined:
 	version has a value which is a string
 	git_commit_hash has a value which is a string
 	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
 	narrative_method_ids has a value which is a reference to a list where each element is a string
 	docker_img_name has a value which is a string
 	data_folder has a value which is a string
 	data_version has a value which is a string
 	compilation_report has a value which is a Catalog.CompilationReport
+boolean is an int
 CompilationReport is a reference to a hash where the following keys are defined:
 	sdk_version has a value which is a string
 	sdk_git_commit has a value which is a string
@@ -1747,8 +1759,7 @@ BasicModuleVersionInfo is a reference to a hash where the following keys are def
 $filter is a Catalog.ListServiceModuleParams
 $service_modules is a reference to a list where each element is a Catalog.BasicModuleVersionInfo
 ListServiceModuleParams is a reference to a hash where the following keys are defined:
-	all_versions has a value which is a Catalog.boolean
-boolean is an int
+	tag has a value which is a string
 BasicModuleVersionInfo is a reference to a hash where the following keys are defined:
 	module_name has a value which is a string
 	version has a value which is a string
@@ -1763,8 +1774,7 @@ BasicModuleVersionInfo is a reference to a hash where the following keys are def
 $filter is a Catalog.ListServiceModuleParams
 $service_modules is a reference to a list where each element is a Catalog.BasicModuleVersionInfo
 ListServiceModuleParams is a reference to a hash where the following keys are defined:
-	all_versions has a value which is a Catalog.boolean
-boolean is an int
+	tag has a value which is a string
 BasicModuleVersionInfo is a reference to a hash where the following keys are defined:
 	module_name has a value which is a string
 	version has a value which is a string
@@ -4100,6 +4110,7 @@ registration_id has a value which is a string
 version has a value which is a string
 git_commit_hash has a value which is a string
 git_commit_message has a value which is a string
+dynamic_service has a value which is a Catalog.boolean
 narrative_method_ids has a value which is a reference to a list where each element is a string
 docker_img_name has a value which is a string
 data_folder has a value which is a string
@@ -4118,6 +4129,7 @@ registration_id has a value which is a string
 version has a value which is a string
 git_commit_hash has a value which is a string
 git_commit_message has a value which is a string
+dynamic_service has a value which is a Catalog.boolean
 narrative_method_ids has a value which is a reference to a list where each element is a string
 docker_img_name has a value which is a string
 data_folder has a value which is a string
@@ -4319,13 +4331,19 @@ only_service_versions has a value which is a Catalog.boolean
 
 
 
+=item Description
+
+tag = dev | beta | release
+if tag is not set, all release versions are returned
+
+
 =item Definition
 
 =begin html
 
 <pre>
 a reference to a hash where the following keys are defined:
-all_versions has a value which is a Catalog.boolean
+tag has a value which is a string
 
 </pre>
 
@@ -4334,7 +4352,7 @@ all_versions has a value which is a Catalog.boolean
 =begin text
 
 a reference to a hash where the following keys are defined:
-all_versions has a value which is a Catalog.boolean
+tag has a value which is a string
 
 
 =end text

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -1634,6 +1634,200 @@ FunctionPlace is a reference to a hash where the following keys are defined:
  
 
 
+=head2 module_version_lookup
+
+  $return = $obj->module_version_lookup($selection)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$selection is a Catalog.ModuleVersionLookupParams
+$return is a Catalog.BasicModuleVersionInfo
+ModuleVersionLookupParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	lookup has a value which is a string
+	only_service_versions has a value which is a Catalog.boolean
+boolean is an int
+BasicModuleVersionInfo is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	version has a value which is a string
+	git_commit_hash has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$selection is a Catalog.ModuleVersionLookupParams
+$return is a Catalog.BasicModuleVersionInfo
+ModuleVersionLookupParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	lookup has a value which is a string
+	only_service_versions has a value which is a Catalog.boolean
+boolean is an int
+BasicModuleVersionInfo is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	version has a value which is a string
+	git_commit_hash has a value which is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub module_version_lookup
+{
+    my($self, @args) = @_;
+
+# Authentication: none
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function module_version_lookup (received $n, expecting 1)");
+    }
+    {
+	my($selection) = @args;
+
+	my @_bad_arguments;
+        (ref($selection) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"selection\" (value was \"$selection\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to module_version_lookup:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'module_version_lookup');
+	}
+    }
+
+    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
+	method => "Catalog.module_version_lookup",
+	params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'module_version_lookup',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method module_version_lookup",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'module_version_lookup',
+				       );
+    }
+}
+ 
+
+
+=head2 list_service_modules
+
+  $service_modules = $obj->list_service_modules($filter)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$filter is a Catalog.ListServiceModuleParams
+$service_modules is a reference to a list where each element is a Catalog.BasicModuleVersionInfo
+ListServiceModuleParams is a reference to a hash where the following keys are defined:
+	all_versions has a value which is a Catalog.boolean
+boolean is an int
+BasicModuleVersionInfo is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	version has a value which is a string
+	git_commit_hash has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$filter is a Catalog.ListServiceModuleParams
+$service_modules is a reference to a list where each element is a Catalog.BasicModuleVersionInfo
+ListServiceModuleParams is a reference to a hash where the following keys are defined:
+	all_versions has a value which is a Catalog.boolean
+boolean is an int
+BasicModuleVersionInfo is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	version has a value which is a string
+	git_commit_hash has a value which is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub list_service_modules
+{
+    my($self, @args) = @_;
+
+# Authentication: none
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function list_service_modules (received $n, expecting 1)");
+    }
+    {
+	my($filter) = @args;
+
+	my @_bad_arguments;
+        (ref($filter) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"filter\" (value was \"$filter\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to list_service_modules:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'list_service_modules');
+	}
+    }
+
+    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
+	method => "Catalog.list_service_modules",
+	params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'list_service_modules',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method list_service_modules",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'list_service_modules',
+				       );
+    }
+}
+ 
+
+
 =head2 set_registration_state
 
   $obj->set_registration_state($params)
@@ -4035,10 +4229,129 @@ version has a value which is a string
 
 
 
+=head2 BasicModuleVersionInfo
+
+=over 4
+
+
+
+=item Description
+
+DYNAMIC SERVICES SUPPORT Methods
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+version has a value which is a string
+git_commit_hash has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+version has a value which is a string
+git_commit_hash has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 ModuleVersionLookupParams
+
+=over 4
+
+
+
+=item Description
+
+module_name - required for module lookup
+lookup - a lookup string, if empty will get the latest released module
+            1) version tag = dev | beta | release
+            2) semantic version match identifiier
+            not supported yet: 3) exact commit hash
+            not supported yet: 4) exact timestamp
+only_service_versions - 1/0, default is 1
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+lookup has a value which is a string
+only_service_versions has a value which is a Catalog.boolean
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+lookup has a value which is a string
+only_service_versions has a value which is a Catalog.boolean
+
+
+=end text
+
+=back
+
+
+
+=head2 ListServiceModuleParams
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+all_versions has a value which is a Catalog.boolean
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+all_versions has a value which is a Catalog.boolean
+
+
+=end text
+
+=back
+
+
+
 =head2 SetRegistrationStateParams
 
 =over 4
 
+
+
+=item Description
+
+End Dynamic Services Support Methods
 
 
 =item Definition

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -278,6 +278,20 @@ class Catalog(object):
                           [params], json_rpc_context)
         return resp[0]
   
+    def module_version_lookup(self, selection, json_rpc_context = None):
+        if json_rpc_context and type(json_rpc_context) is not dict:
+            raise ValueError('Method module_version_lookup: argument json_rpc_context is not type dict as required.')
+        resp = self._call('Catalog.module_version_lookup',
+                          [selection], json_rpc_context)
+        return resp[0]
+  
+    def list_service_modules(self, filter, json_rpc_context = None):
+        if json_rpc_context and type(json_rpc_context) is not dict:
+            raise ValueError('Method list_service_modules: argument json_rpc_context is not type dict as required.')
+        resp = self._call('Catalog.list_service_modules',
+                          [filter], json_rpc_context)
+        return resp[0]
+  
     def set_registration_state(self, params, json_rpc_context = None):
         if json_rpc_context and type(json_rpc_context) is not dict:
             raise ValueError('Method set_registration_state: argument json_rpc_context is not type dict as required.')

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -232,6 +232,33 @@ class Catalog:
         # return the results
         return [versions]
 
+    def module_version_lookup(self, ctx, selection):
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN module_version_lookup
+        #END module_version_lookup
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method module_version_lookup return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
+    def list_service_modules(self, ctx, filter):
+        # ctx is the context object
+        # return variables are: service_modules
+        #BEGIN list_service_modules
+        service_modules = self.cc.list_service_modules(filter)
+        #END list_service_modules
+
+        # At some point might do deeper type checking...
+        if not isinstance(service_modules, list):
+            raise ValueError('Method list_service_modules return value ' +
+                             'service_modules is not type list as required.')
+        # return the results
+        return [service_modules]
+
     def set_registration_state(self, ctx, params):
         # ctx is the context object
         #BEGIN set_registration_state

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -236,6 +236,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN module_version_lookup
+        returnVal = self.cc.module_version_lookup(selection)
         #END module_version_lookup
 
         # At some point might do deeper type checking...

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -109,6 +109,12 @@ sync_methods['Catalog.get_version_info'] = True
 async_run_methods['Catalog.list_released_module_versions_async'] = ['Catalog', 'list_released_module_versions']
 async_check_methods['Catalog.list_released_module_versions_check'] = ['Catalog', 'list_released_module_versions']
 sync_methods['Catalog.list_released_module_versions'] = True
+async_run_methods['Catalog.module_version_lookup_async'] = ['Catalog', 'module_version_lookup']
+async_check_methods['Catalog.module_version_lookup_check'] = ['Catalog', 'module_version_lookup']
+sync_methods['Catalog.module_version_lookup'] = True
+async_run_methods['Catalog.list_service_modules_async'] = ['Catalog', 'list_service_modules']
+async_check_methods['Catalog.list_service_modules_check'] = ['Catalog', 'list_service_modules']
+sync_methods['Catalog.list_service_modules'] = True
 async_run_methods['Catalog.set_registration_state_async'] = ['Catalog', 'set_registration_state']
 async_check_methods['Catalog.set_registration_state_check'] = ['Catalog', 'set_registration_state']
 sync_methods['Catalog.set_registration_state'] = True
@@ -501,6 +507,14 @@ class Application(object):
                              name='Catalog.list_released_module_versions',
                              types=[dict])
         self.method_authentication['Catalog.list_released_module_versions'] = 'none'
+        self.rpc_service.add(impl_Catalog.module_version_lookup,
+                             name='Catalog.module_version_lookup',
+                             types=[dict])
+        self.method_authentication['Catalog.module_version_lookup'] = 'none'
+        self.rpc_service.add(impl_Catalog.list_service_modules,
+                             name='Catalog.list_service_modules',
+                             types=[dict])
+        self.method_authentication['Catalog.list_service_modules'] = 'none'
         self.rpc_service.add(impl_Catalog.set_registration_state,
                              name='Catalog.set_registration_state',
                              types=[dict])

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -763,9 +763,9 @@ class CatalogController:
 
 
         # assume semantic versioning which only can select released versions
+        # we should optimize to fetch only the details/versions we need from mongo.
         details = self.db.get_module_full_details(module_name=selection['module_name'])
         versions = details['release_version_list']
-
 
         spec = semantic_version.Spec(lookup)
         svers = []

--- a/lib/biokbase/catalog/db.py
+++ b/lib/biokbase/catalog/db.py
@@ -498,9 +498,6 @@ class MongoCatalogDBI:
 
 
 
-
-
-
     #### developer check methods
 
     def approve_developer(self, developer):

--- a/lib/biokbase/catalog/db.py
+++ b/lib/biokbase/catalog/db.py
@@ -69,6 +69,11 @@ Module Document:
                 registration_id:''
             }
         }
+
+        release_version_list: [
+
+
+        ]
     }
 
 FAVORITES
@@ -179,6 +184,9 @@ class MongoCatalogDBI:
         # client group
         #  app_id = [lower case module name]/[app id]
         self.client_groups.ensure_index('app_id', unique=True, sparse=False)
+
+
+        self.correct_release_versions()
 
 
     def is_registered(self,module_name='',git_url=''):
@@ -317,7 +325,7 @@ class MongoCatalogDBI:
                     'registration_id' : registration_id
                 }
             },
-            'release_versions': { }
+            'release_version_list': []
         }
         self.modules.insert(module)
 
@@ -357,8 +365,10 @@ class MongoCatalogDBI:
         # we both update the release version, and since we archive release versions, we stash it in the release_versions list as well
         result = self.modules.update(query, {'$set':{
                                                 'state.released':True,
-                                                'current_versions.release':beta_version,
-                                                'release_versions.'+str(beta_version['timestamp']):beta_version
+                                                'current_versions.release':beta_version
+                                                },
+                                             '$push':{
+                                                'release_version_list':beta_version
                                                 }})
         return self._check_update_result(result)
 
@@ -445,6 +455,52 @@ class MongoCatalogDBI:
         return list(self.modules.find(query,{'module_name':1,'git_url':1,'current_versions':1,'owners':1,'_id':0}))
 
 
+
+
+
+
+    # tag should be one of dev, beta, release - do checking outside of this method
+    def list_service_module_versions_with_tag(self, tag):
+        query = {'info.dynamic_service':True, 'current_versions.'+tag+'.dynamic_service':True}
+        projection = {
+            '_id':0,
+            'module_name':1,
+            'current_versions.'+tag+'.version':1,
+            'current_versions.'+tag+'.git_commit_hash':1
+        }
+        result = []
+        for m in self.modules.find(query,projection):
+            result.append({
+                'module_name':m['module_name'],
+                'version':m['current_versions'][tag]['version'],
+                'git_commit_hash':m['current_versions'][tag]['git_commit_hash']})
+        return result
+
+
+    # all released service module versions
+    def list_all_released_service_module_versions(self):
+        result = self.modules.aggregate([
+            {'$match':{'info.dynamic_service':True}}, # make sure it is a module that has at least one dynamic service
+            {'$unwind':"$release_version_list"},      # look at all the release versions
+            {'$match':{'release_version_list.dynamic_service':True}}, # find the dynamic service released versions
+            {'$project':{
+                    'module_name':1,
+                    'version':'$release_version_list.version',
+                    'git_commit_hash':'$release_version_list.git_commit_hash',
+                    '_id':0
+                }
+            }])
+
+        return list(result['result'])
+
+
+
+
+
+
+
+
+
     #### developer check methods
 
     def approve_developer(self, developer):
@@ -496,7 +552,7 @@ class MongoCatalogDBI:
         if module_details['current_versions']['release']:
             raise ValueError('Cannot delete module that has been released.  Make it inactive instead.')
 
-        if module_details['release_versions']:
+        if module_details['release_version_list']:
             raise ValueError('Cannot delete module that has released versions.  Make it inactive instead.')
 
         result = self.modules.remove({'_id':module_details['_id']})
@@ -771,4 +827,27 @@ class MongoCatalogDBI:
 
         return counts
 
-        
+    
+
+
+    # release versions used to be in a map, but this makes mongo queries difficult
+    # here we switch that in an existing db to a release_version_list
+    def correct_release_versions(self):
+        for m in self.modules.find({'release_versions': {'$exists' : True}}):
+            release_version_list = []
+            for timestamp in m['release_versions']:
+                release_version_list.append(m['release_versions'][timestamp])
+
+            self.modules.update(
+                {'_id':m['_id']},
+                {
+                    '$unset':{'release_versions':''},
+                    '$set':{'release_version_list':release_version_list}
+                })
+
+
+
+
+
+
+

--- a/lib/biokbase/catalog/registrar.py
+++ b/lib/biokbase/catalog/registrar.py
@@ -225,6 +225,13 @@ class Registrar:
         service_language = self.get_required_field_as_string(self.kb_yaml,'service-language').strip()
         owners = self.get_required_field_as_list(self.kb_yaml,'owners')
 
+        service_config = self.get_optional_field_as_dict(self.kb_yaml, 'service-config')
+        if service_config:
+            # validate service_config parameters
+            if 'dynamic-service' in service_config:
+                if not type(service_config['dynamic-service']) == type(True):
+                    raise ValueError('Invalid service-config in kbase.yaml - "dynamic-service" property must be a boolean "true" or "false".') 
+
         # module_name must match what exists (unless it is not yet defined)
         if 'module_name' in self.module_details:
             if self.module_details['module_name'] != module_name:
@@ -273,6 +280,7 @@ class Registrar:
         version = self.get_required_field_as_string(self.kb_yaml,'module-version')
         service_language = self.get_required_field_as_string(self.kb_yaml,'service-language')
         owners = self.get_required_field_as_list(self.kb_yaml,'owners')
+        service_config = self.get_optional_field_as_dict(self.kb_yaml, 'service-config')
 
         # first update the module name, which is now permanent, if we haven't already
         if ('module_name' not in self.module_details) or ('module_name_lc' not in self.module_details):
@@ -289,6 +297,10 @@ class Registrar:
             'description': module_description,
             'language' : service_language
         }
+        if service_config and service_config['dynamic-service']:
+            info['dynamic_service'] = 1
+        else:
+            info['dynamic_service'] = 0
         self.log('new info: '+pprint.pformat(info))
         error = self.db.set_module_info(info, git_url=self.git_url)
         if error is not None:
@@ -324,6 +336,11 @@ class Registrar:
         if ref_data_ver:
             new_version['data_folder'] = ref_data_folder
             new_version['data_version'] = ref_data_ver
+        if service_config and service_config['dynamic-service']:
+            new_version['dynamic_service'] = 1
+        else:
+            new_version['dynamic_service'] = 0
+
         self.log('new dev version object: '+pprint.pformat(new_version))
         error = self.db.update_dev_version(new_version, git_url=self.git_url)
         if error is not None:
@@ -407,6 +424,15 @@ class Registrar:
         if not type(value) is list:
             raise ValueError('kbase.yaml file "'+field_name+'" required field must be a list')
         return value
+
+    def get_optional_field_as_dict(self, kb_yaml, field_name):
+        if field_name not in kb_yaml:
+            return None
+        value = kb_yaml[field_name]
+        if not type(value) is dict:
+            raise ValueError('kbase.yaml file "'+field_name+'" optional field must be a dict')
+        return value
+
 
 
     def log(self, message, no_end_line=False, is_error=False):

--- a/lib/java/us/kbase/catalog/BasicModuleVersionInfo.java
+++ b/lib/java/us/kbase/catalog/BasicModuleVersionInfo.java
@@ -1,0 +1,98 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: BasicModuleVersionInfo</p>
+ * <pre>
+ * DYNAMIC SERVICES SUPPORT Methods
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "module_name",
+    "version",
+    "git_commit_hash"
+})
+public class BasicModuleVersionInfo {
+
+    @JsonProperty("module_name")
+    private String moduleName;
+    @JsonProperty("version")
+    private String version;
+    @JsonProperty("git_commit_hash")
+    private String gitCommitHash;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("module_name")
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    @JsonProperty("module_name")
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public BasicModuleVersionInfo withModuleName(String moduleName) {
+        this.moduleName = moduleName;
+        return this;
+    }
+
+    @JsonProperty("version")
+    public String getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public BasicModuleVersionInfo withVersion(String version) {
+        this.version = version;
+        return this;
+    }
+
+    @JsonProperty("git_commit_hash")
+    public String getGitCommitHash() {
+        return gitCommitHash;
+    }
+
+    @JsonProperty("git_commit_hash")
+    public void setGitCommitHash(String gitCommitHash) {
+        this.gitCommitHash = gitCommitHash;
+    }
+
+    public BasicModuleVersionInfo withGitCommitHash(String gitCommitHash) {
+        this.gitCommitHash = gitCommitHash;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("BasicModuleVersionInfo"+" [moduleName=")+ moduleName)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -410,6 +410,40 @@ public class CatalogClient {
     }
 
     /**
+     * <p>Original spec-file function name: module_version_lookup</p>
+     * <pre>
+     * </pre>
+     * @param   selection   instance of type {@link us.kbase.catalog.ModuleVersionLookupParams ModuleVersionLookupParams}
+     * @return   instance of type {@link us.kbase.catalog.BasicModuleVersionInfo BasicModuleVersionInfo}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public BasicModuleVersionInfo moduleVersionLookup(ModuleVersionLookupParams selection, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(selection);
+        TypeReference<List<BasicModuleVersionInfo>> retType = new TypeReference<List<BasicModuleVersionInfo>>() {};
+        List<BasicModuleVersionInfo> res = caller.jsonrpcCall("Catalog.module_version_lookup", args, retType, true, false, jsonRpcContext);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: list_service_modules</p>
+     * <pre>
+     * </pre>
+     * @param   filter   instance of type {@link us.kbase.catalog.ListServiceModuleParams ListServiceModuleParams}
+     * @return   parameter "service_modules" of list of type {@link us.kbase.catalog.BasicModuleVersionInfo BasicModuleVersionInfo}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public List<BasicModuleVersionInfo> listServiceModules(ListServiceModuleParams filter, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(filter);
+        TypeReference<List<List<BasicModuleVersionInfo>>> retType = new TypeReference<List<List<BasicModuleVersionInfo>>>() {};
+        List<List<BasicModuleVersionInfo>> res = caller.jsonrpcCall("Catalog.list_service_modules", args, retType, true, false, jsonRpcContext);
+        return res.get(0);
+    }
+
+    /**
      * <p>Original spec-file function name: set_registration_state</p>
      * <pre>
      * </pre>

--- a/lib/java/us/kbase/catalog/ListServiceModuleParams.java
+++ b/lib/java/us/kbase/catalog/ListServiceModuleParams.java
@@ -1,0 +1,60 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ListServiceModuleParams</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "all_versions"
+})
+public class ListServiceModuleParams {
+
+    @JsonProperty("all_versions")
+    private Long allVersions;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("all_versions")
+    public Long getAllVersions() {
+        return allVersions;
+    }
+
+    @JsonProperty("all_versions")
+    public void setAllVersions(Long allVersions) {
+        this.allVersions = allVersions;
+    }
+
+    public ListServiceModuleParams withAllVersions(Long allVersions) {
+        this.allVersions = allVersions;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((("ListServiceModuleParams"+" [allVersions=")+ allVersions)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/ListServiceModuleParams.java
+++ b/lib/java/us/kbase/catalog/ListServiceModuleParams.java
@@ -13,32 +13,35 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * <p>Original spec-file type: ListServiceModuleParams</p>
- * 
+ * <pre>
+ * tag = dev | beta | release
+ * if tag is not set, all release versions are returned
+ * </pre>
  * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
-    "all_versions"
+    "tag"
 })
 public class ListServiceModuleParams {
 
-    @JsonProperty("all_versions")
-    private Long allVersions;
+    @JsonProperty("tag")
+    private String tag;
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
-    @JsonProperty("all_versions")
-    public Long getAllVersions() {
-        return allVersions;
+    @JsonProperty("tag")
+    public String getTag() {
+        return tag;
     }
 
-    @JsonProperty("all_versions")
-    public void setAllVersions(Long allVersions) {
-        this.allVersions = allVersions;
+    @JsonProperty("tag")
+    public void setTag(String tag) {
+        this.tag = tag;
     }
 
-    public ListServiceModuleParams withAllVersions(Long allVersions) {
-        this.allVersions = allVersions;
+    public ListServiceModuleParams withTag(String tag) {
+        this.tag = tag;
         return this;
     }
 
@@ -54,7 +57,7 @@ public class ListServiceModuleParams {
 
     @Override
     public String toString() {
-        return ((((("ListServiceModuleParams"+" [allVersions=")+ allVersions)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((("ListServiceModuleParams"+" [tag=")+ tag)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/ModuleVersionInfo.java
+++ b/lib/java/us/kbase/catalog/ModuleVersionInfo.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "version",
     "git_commit_hash",
     "git_commit_message",
+    "dynamic_service",
     "narrative_method_ids",
     "docker_img_name",
     "data_folder",
@@ -53,6 +54,8 @@ public class ModuleVersionInfo {
     private java.lang.String gitCommitHash;
     @JsonProperty("git_commit_message")
     private java.lang.String gitCommitMessage;
+    @JsonProperty("dynamic_service")
+    private Long dynamicService;
     @JsonProperty("narrative_method_ids")
     private List<String> narrativeMethodIds;
     @JsonProperty("docker_img_name")
@@ -142,6 +145,21 @@ public class ModuleVersionInfo {
 
     public ModuleVersionInfo withGitCommitMessage(java.lang.String gitCommitMessage) {
         this.gitCommitMessage = gitCommitMessage;
+        return this;
+    }
+
+    @JsonProperty("dynamic_service")
+    public Long getDynamicService() {
+        return dynamicService;
+    }
+
+    @JsonProperty("dynamic_service")
+    public void setDynamicService(Long dynamicService) {
+        this.dynamicService = dynamicService;
+    }
+
+    public ModuleVersionInfo withDynamicService(Long dynamicService) {
+        this.dynamicService = dynamicService;
         return this;
     }
 
@@ -242,7 +260,7 @@ public class ModuleVersionInfo {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((("ModuleVersionInfo"+" [timestamp=")+ timestamp)+", registrationId=")+ registrationId)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", gitCommitMessage=")+ gitCommitMessage)+", narrativeMethodIds=")+ narrativeMethodIds)+", dockerImgName=")+ dockerImgName)+", dataFolder=")+ dataFolder)+", dataVersion=")+ dataVersion)+", compilationReport=")+ compilationReport)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((("ModuleVersionInfo"+" [timestamp=")+ timestamp)+", registrationId=")+ registrationId)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", gitCommitMessage=")+ gitCommitMessage)+", dynamicService=")+ dynamicService)+", narrativeMethodIds=")+ narrativeMethodIds)+", dockerImgName=")+ dockerImgName)+", dataFolder=")+ dataFolder)+", dataVersion=")+ dataVersion)+", compilationReport=")+ compilationReport)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/java/us/kbase/catalog/ModuleVersionLookupParams.java
+++ b/lib/java/us/kbase/catalog/ModuleVersionLookupParams.java
@@ -1,0 +1,104 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ModuleVersionLookupParams</p>
+ * <pre>
+ * module_name - required for module lookup
+ * lookup - a lookup string, if empty will get the latest released module
+ *             1) version tag = dev | beta | release
+ *             2) semantic version match identifiier
+ *             not supported yet: 3) exact commit hash
+ *             not supported yet: 4) exact timestamp
+ * only_service_versions - 1/0, default is 1
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "module_name",
+    "lookup",
+    "only_service_versions"
+})
+public class ModuleVersionLookupParams {
+
+    @JsonProperty("module_name")
+    private String moduleName;
+    @JsonProperty("lookup")
+    private String lookup;
+    @JsonProperty("only_service_versions")
+    private Long onlyServiceVersions;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("module_name")
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    @JsonProperty("module_name")
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public ModuleVersionLookupParams withModuleName(String moduleName) {
+        this.moduleName = moduleName;
+        return this;
+    }
+
+    @JsonProperty("lookup")
+    public String getLookup() {
+        return lookup;
+    }
+
+    @JsonProperty("lookup")
+    public void setLookup(String lookup) {
+        this.lookup = lookup;
+    }
+
+    public ModuleVersionLookupParams withLookup(String lookup) {
+        this.lookup = lookup;
+        return this;
+    }
+
+    @JsonProperty("only_service_versions")
+    public Long getOnlyServiceVersions() {
+        return onlyServiceVersions;
+    }
+
+    @JsonProperty("only_service_versions")
+    public void setOnlyServiceVersions(Long onlyServiceVersions) {
+        this.onlyServiceVersions = onlyServiceVersions;
+    }
+
+    public ModuleVersionLookupParams withOnlyServiceVersions(Long onlyServiceVersions) {
+        this.onlyServiceVersions = onlyServiceVersions;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("ModuleVersionLookupParams"+" [moduleName=")+ moduleName)+", lookup=")+ lookup)+", onlyServiceVersions=")+ onlyServiceVersions)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/SetRegistrationStateParams.java
+++ b/lib/java/us/kbase/catalog/SetRegistrationStateParams.java
@@ -13,7 +13,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * <p>Original spec-file type: SetRegistrationStateParams</p>
- * 
+ * <pre>
+ * End Dynamic Services Support Methods
+ * </pre>
  * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -222,6 +222,32 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms, async_ver
             [params], 1, _callback, _errorCallback);
     };
  
+     this.module_version_lookup = function (selection, _callback, _errorCallback) {
+        if (typeof selection === 'function')
+            throw 'Argument selection can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.module_version_lookup",
+            [selection], 1, _callback, _errorCallback);
+    };
+ 
+     this.list_service_modules = function (filter, _callback, _errorCallback) {
+        if (typeof filter === 'function')
+            throw 'Argument filter can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.list_service_modules",
+            [filter], 1, _callback, _errorCallback);
+    };
+ 
      this.set_registration_state = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -81,7 +81,7 @@ class BasicCatalogTest(unittest.TestCase):
             module_names.append(m['module_name'])
         self.assertEqual(
             ",".join(sorted(module_names)),
-            ",".join(['onerepotest','pending_second_release','release_history'])
+            ",".join(['DynamicService','onerepotest','pending_second_release','release_history'])
             )
 
         # all released and unreleased
@@ -92,7 +92,7 @@ class BasicCatalogTest(unittest.TestCase):
             module_names.append(m['module_name'])
         self.assertEqual(
             ",".join(sorted(module_names)),
-            ",".join(sorted(['denied_release','onerepotest','pending_first_release','pending_second_release',
+            ",".join(sorted(['DynamicService','denied_release','onerepotest','pending_first_release','pending_second_release',
                 'registration_error','registration_in_progress','release_history']))
             )
 

--- a/test/dynamic_service_support_test.py
+++ b/test/dynamic_service_support_test.py
@@ -46,7 +46,7 @@ class DynamicServiceSupportTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        pass #cls.cUtil.tearDown()
+        cls.cUtil.tearDown()
 
 
 

--- a/test/dynamic_service_support_test.py
+++ b/test/dynamic_service_support_test.py
@@ -1,0 +1,53 @@
+
+
+import unittest
+import os
+
+from pprint import pprint
+
+from catalog_test_util import CatalogTestUtil
+from biokbase.catalog.Impl import Catalog
+
+
+# tests all the basic get methods
+class DynamicServiceSupportTest(unittest.TestCase):
+
+
+    def test_list_dynamic_modules(self):
+
+        mods = self.catalog.list_service_modules(self.cUtil.anonymous_ctx(),
+            {})[0]
+        pprint(mods)
+
+        #ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+        #    {'module_name':'DynamicService'})[0]
+        #pprint(ver)
+
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+            {'module_name':'DynamicService','only_service_versions':0,'lookup':'>0.0.0,<2.0.0'})[0]
+        print('------')
+        pprint(ver)
+
+
+    #def test_version_fetch_basics(self):
+
+    #    version = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
+    #        {'module_name':'release_history','version':'dev'})[0]
+    #    pprint(version)
+    #    print 'howdy'
+    
+
+    @classmethod
+    def setUpClass(cls):
+        print('++++++++++++ RUNNING version_fetch_test.py +++++++++++')
+        cls.cUtil = CatalogTestUtil('.') # TODO: pass in test directory from outside
+        cls.cUtil.setUp()
+        cls.catalog = Catalog(cls.cUtil.getCatalogConfig())
+
+    @classmethod
+    def tearDownClass(cls):
+        pass #cls.cUtil.tearDown()
+
+
+
+

--- a/test/favorites_test.py
+++ b/test/favorites_test.py
@@ -57,6 +57,7 @@ class BasicCatalogTest(unittest.TestCase):
         self.catalog.add_favorite(ctx,
             {'id':'run_fba'})
         favs3 = self.catalog.list_favorites(ctx, user)[0]
+        pprint(favs3)
         self.assertEqual(len(favs3),3)
         self.assertEqual(favs3[0]['module_name_lc'],'nms.legacy')
         self.assertEqual(favs3[0]['id'],'run_fba')

--- a/test/favorites_test.py
+++ b/test/favorites_test.py
@@ -43,6 +43,7 @@ class BasicCatalogTest(unittest.TestCase):
         self.catalog.add_favorite(ctx,
             {'module_name':'MegaHit', 'id':'run_megahit_2'})
         favs2 = self.catalog.list_favorites({}, user)[0]
+        favs2.sort(key=lambda x: x['timestamp'], reverse=True)
         self.assertEqual(len(favs2),2)
         self.assertEqual(favs2[0]['module_name_lc'],'megahit')
         self.assertEqual(favs2[0]['id'],'run_megahit_2')
@@ -57,7 +58,7 @@ class BasicCatalogTest(unittest.TestCase):
         self.catalog.add_favorite(ctx,
             {'id':'run_fba'})
         favs3 = self.catalog.list_favorites(ctx, user)[0]
-        pprint(favs3)
+        favs3.sort(key=lambda x: x['timestamp'], reverse=True)
         self.assertEqual(len(favs3),3)
         self.assertEqual(favs3[0]['module_name_lc'],'nms.legacy')
         self.assertEqual(favs3[0]['id'],'run_fba')
@@ -67,6 +68,7 @@ class BasicCatalogTest(unittest.TestCase):
         self.catalog.remove_favorite(ctx,
             {'module_name':'MegaHit', 'id':'run_megahit_2'})
         favs4 = self.catalog.list_favorites(ctx, user)[0]
+        favs4.sort(key=lambda x: x['timestamp'], reverse=True)
         self.assertEqual(len(favs4),2)
         self.assertEqual(favs4[0]['module_name_lc'],'nms.legacy')
         self.assertEqual(favs4[0]['id'],'run_fba')

--- a/test/initial_mongo_state/modules/dynamic_service.json
+++ b/test/initial_mongo_state/modules/dynamic_service.json
@@ -87,7 +87,6 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.d6cd1e2bd19e03a81132a23b2025920577f84e37",
             "git_commit_message" : "something else",
             "version" : "1.1.0",
-            "dynamic_service" : true,
             "narrative_methods" : [
                 "get_genomes"
             ]
@@ -100,6 +99,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
             "git_commit_message" : "and another thing",
             "version" : "1.0.2",
+            "dynamic_service" : true,
             "narrative_methods" : [
                 "get_genomes"
             ]

--- a/test/initial_mongo_state/modules/dynamic_service.json
+++ b/test/initial_mongo_state/modules/dynamic_service.json
@@ -6,7 +6,7 @@
     "info" : {
         "description" : "KBase module for stuff",
         "language" : "python",
-        "dynamic_service" : true
+        "dynamic_service" : 1
     },
 
     "owners" : [
@@ -35,7 +35,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.b06c5f9daf603a4d206071787c3f6184000bf128",
             "git_commit_message" : "another change",
             "version" : "0.0.5",
-            "dynamic_service" : true,
+            "dynamic_service" : 1,
             "narrative_methods" : [
                 "send_data2"
             ]
@@ -47,7 +47,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.4",
-            "dynamic_service" : true,
+            "dynamic_service" : 1,
             "narrative_methods" : [
                 "send_data"
             ]
@@ -59,7 +59,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "2.1.8",
-            "dynamic_service" : true,
+            "dynamic_service" : 1,
             "narrative_methods" : [
                 "send_data"
             ]
@@ -74,7 +74,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7",
             "git_commit_message" : "added username for testing",
             "version" : "2.1.8",
-            "dynamic_service" : true,
+            "dynamic_service" : 1,
             "narrative_methods" : [
                 "get_genomes"
             ]
@@ -99,7 +99,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
             "git_commit_message" : "and another thing",
             "version" : "1.0.2",
-            "dynamic_service" : true,
+            "dynamic_service" : 1,
             "narrative_methods" : [
                 "get_genomes"
             ]
@@ -112,7 +112,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
             "git_commit_message" : "first thing",
             "version" : "1.0.1",
-            "dynamic_service" : true,
+            "dynamic_service" : 1,
             "narrative_methods" : [
                 "get_genomes"
             ]

--- a/test/initial_mongo_state/modules/dynamic_service.json
+++ b/test/initial_mongo_state/modules/dynamic_service.json
@@ -1,0 +1,121 @@
+{
+    "module_name" : "DynamicService",
+    "module_name_lc" : "dynamicservice",
+    "git_url" : "https://github.com/kbaseIncubator/dynamic_service",
+
+    "info" : {
+        "description" : "KBase module for stuff",
+        "language" : "python",
+        "dynamic_service" : true
+    },
+
+    "owners" : [
+        {
+            "kb_username" : "rsutormin"
+        },
+        {
+            "kb_username" : "wstester2"
+        }
+    ],
+
+    "state" : {
+        "active" : true,
+        "error_message" : "",
+        "registration" : "complete",
+        "release_approval" : "approved",
+        "released" : true,
+        "review_message" : ""
+    },
+
+    "current_versions" : {
+        "dev" : {
+            "git_commit_hash" : "b06c5f9daf603a4d206071787c3f6184000bf128",
+            "timestamp" : 1445024094055,
+            "registration_id" : "1445024094055_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.b06c5f9daf603a4d206071787c3f6184000bf128",
+            "git_commit_message" : "another change",
+            "version" : "0.0.5",
+            "dynamic_service" : true,
+            "narrative_methods" : [
+                "send_data2"
+            ]
+        },
+        "beta" : {
+            "git_commit_hash" : "b843888e962642d665a3b0bd701ee630c01835e6",
+            "timestamp" : 1445023985597,
+            "registration_id" : "1445023985597_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.b843888e962642d665a3b0bd701ee630c01835e6",
+            "git_commit_message" : "update for testing",
+            "version" : "0.0.4",
+            "dynamic_service" : true,
+            "narrative_methods" : [
+                "send_data"
+            ]
+        },
+        "release" : {
+            "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
+            "timestamp" : 1445022818885,
+            "registration_id" : "1445022818884_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7",
+            "git_commit_message" : "added username for testing",
+            "version" : "2.1.8",
+            "dynamic_service" : true,
+            "narrative_methods" : [
+                "send_data"
+            ]
+        }
+    },
+
+    "release_version_list" : [
+        {
+            "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
+            "timestamp" : 1445022818885,
+            "registration_id" : "1445022818885_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7",
+            "git_commit_message" : "added username for testing",
+            "version" : "2.1.8",
+            "dynamic_service" : true,
+            "narrative_methods" : [
+                "get_genomes"
+            ]
+        },
+
+        {
+            "git_commit_hash" : "d6cd1e2bd19e03a81132a23b2025920577f84e37",
+            "timestamp" : 1445022818003,
+            "registration_id" : "1445022818003_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.d6cd1e2bd19e03a81132a23b2025920577f84e37",
+            "git_commit_message" : "something else",
+            "version" : "1.1.0",
+            "dynamic_service" : true,
+            "narrative_methods" : [
+                "get_genomes"
+            ]
+        },
+
+        {
+            "git_commit_hash" : "9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
+            "timestamp" : 1445022815002,
+            "registration_id" : "1445022815002_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
+            "git_commit_message" : "and another thing",
+            "version" : "1.0.2",
+            "narrative_methods" : [
+                "get_genomes"
+            ]
+        },
+
+        {
+            "git_commit_hash" : "9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
+            "timestamp" : 1445022815001,
+            "registration_id" : "1445022815001_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
+            "git_commit_message" : "first thing",
+            "version" : "1.0.1",
+            "dynamic_service" : true,
+            "narrative_methods" : [
+                "get_genomes"
+            ]
+        }
+    ]
+}

--- a/test/initial_mongo_state/modules/onerepotest.json
+++ b/test/initial_mongo_state/modules/onerepotest.json
@@ -62,8 +62,8 @@
         }
     },
 
-    "release_versions" : {
-        "1445022818884" : {
+    "release_version_list" : [
+        {
             "git_commit_hash" : "49dc505febb8f4cccb2078c58ded0de3320534d7",
             "timestamp" : 1445022818884,
             "registration_id" : "1445022818884_1245",
@@ -74,5 +74,5 @@
                 "send_data"
             ]
         }
-    }
+    ]
 }

--- a/test/test.cfg.example
+++ b/test/test.cfg.example
@@ -51,7 +51,7 @@ method-spec-git-repo-local-dir = nms/local_narrative_method_specs
 method-spec-temp-dir = nms/scratch
 
 method-spec-git-repo = https://github.com/kbase/narrative_method_specs
-method-spec-git-repo-branch = dev
+method-spec-git-repo-branch = develop
 method-spec-git-repo-refresh-rate = 2000
 method-spec-cache-size = 5000
 method-spec-mongo-dbname = method_store_repo_db


### PR DESCRIPTION
Allows module versions to be tagged as a dynamic service.  Also on startup updates the mongo module structure slightly to improve released version queries and add dynamic service flags.  Finally, this PR adds new methods for listing versions marked as a dynamic service and resolving semantic version requirements (useful to allow dynamic service clients to request the latest compatible version).