### PR TITLE
Minor bug fixes and adding proper tests

### DIFF
--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -753,7 +753,7 @@ class CatalogController:
 
                 if only_services:
                     if 'dynamic_service' in version:
-                        if not service['dynamic_service']:
+                        if not version['dynamic_service']:
                             raise ValueError('The "'+selection['lookup']+'" version is not marked as a Service Module.')
                 return {
                     'module_name': details['module_name'],

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -81,7 +81,7 @@ class BasicCatalogTest(unittest.TestCase):
             module_names.append(m['module_name'])
         self.assertEqual(
             ",".join(sorted(module_names)),
-            ",".join(['DynamicService','onerepotest','pending_second_release','release_history'])
+            ",".join(['DynamicService','DynamicService2','onerepotest','pending_second_release','release_history'])
             )
 
         # all released and unreleased
@@ -92,7 +92,7 @@ class BasicCatalogTest(unittest.TestCase):
             module_names.append(m['module_name'])
         self.assertEqual(
             ",".join(sorted(module_names)),
-            ",".join(sorted(['DynamicService','denied_release','onerepotest','pending_first_release','pending_second_release',
+            ",".join(sorted(['DynamicService','DynamicService2','denied_release','onerepotest','pending_first_release','pending_second_release',
                 'registration_error','registration_in_progress','release_history']))
             )
 

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -459,7 +459,7 @@ class CoreRegistrationTest(unittest.TestCase):
 
 
         # TODO test method store to be sure we can get old method specs by commit hash
-        pprint(info)
+        #pprint(info)
 
 
     def validate_basic_test_module_info_fields(self,info,giturl,module_name,owners):

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -376,7 +376,11 @@ class CoreRegistrationTest(unittest.TestCase):
         self.assertEqual(state['registration'],'error')
         log = self.catalog.get_parsed_build_log(self.cUtil.anonymous_ctx(),{'registration_id':registration_id3})
         self.assertTrue(log is not None)
-        self.assertTrue('must be in semantic version format' in log[0]['error_message'])
+        found_correct_error = False
+        for l in log:
+            if 'must be in semantic version format' in l['error_message']:
+                found_correct_error = True
+        self.assertTrue(found_correct_error, 'correct error was thrown in log for semantic version error')
 
         #Register new version, but with same version number as in the release so should fail
         githash4 = '6add31077a4982d6c8a5bc161915d30bfec3fe0c' # branch simple_good_repo

--- a/test/dynamic_service_support_test.py
+++ b/test/dynamic_service_support_test.py
@@ -15,27 +15,168 @@ class DynamicServiceSupportTest(unittest.TestCase):
 
     def test_list_dynamic_modules(self):
 
+        # first fetch without a tag, we should get all released versions
         mods = self.catalog.list_service_modules(self.cUtil.anonymous_ctx(),
             {})[0]
-        pprint(mods)
+        mods.sort(key = lambda x: x['version'])
+        self.assertEqual(len(mods),4)
 
-        #ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
-        #    {'module_name':'DynamicService'})[0]
-        #pprint(ver)
+        self.assertEqual(mods[0]['module_name'],'DynamicService')
+        self.assertEqual(mods[0]['git_commit_hash'],'9bedf67800b2923982bdf60c89c57ce6fd2d9a1c')
+        self.assertEqual(mods[0]['version'],'1.0.1')
+
+        self.assertEqual(mods[1]['module_name'],'DynamicService')
+        self.assertEqual(mods[1]['git_commit_hash'],'12edf67800b2923982bdf60c89c57ce6fd2d9a1c')
+        self.assertEqual(mods[1]['version'],'1.0.2')
+
+        self.assertEqual(mods[2]['module_name'],'DynamicService2')
+        self.assertEqual(mods[2]['git_commit_hash'],'29dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(mods[2]['version'],'1.5.0')
+
+        self.assertEqual(mods[3]['module_name'],'DynamicService')
+        self.assertEqual(mods[3]['git_commit_hash'],'49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(mods[3]['version'],'2.1.8')
+        
+        # get all dev services
+        mods = self.catalog.list_service_modules(self.cUtil.anonymous_ctx(),
+            {'tag':'dev'})[0]
+        self.assertEqual(len(mods),1)
+        self.assertEqual(mods[0]['module_name'],'DynamicService')
+        self.assertEqual(mods[0]['git_commit_hash'],'b06c5f9daf603a4d206071787c3f6184000bf128')
+        self.assertEqual(mods[0]['version'],'0.0.5')
+
+        # get all beta services
+        mods = self.catalog.list_service_modules(self.cUtil.anonymous_ctx(),
+            {'tag':'beta'})[0]
+        mods.sort(key = lambda x: x['version'])
+        self.assertEqual(len(mods),1)
+        self.assertEqual(mods[0]['module_name'],'DynamicService2')
+        self.assertEqual(mods[0]['git_commit_hash'],'39dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(mods[0]['version'],'1.5.1')
+
+        # get all released versions
+        mods = self.catalog.list_service_modules(self.cUtil.anonymous_ctx(),
+            {'tag':'release'})[0]
+        mods.sort(key = lambda x: x['version'])
+        self.assertEqual(len(mods),2)
+
+        self.assertEqual(mods[0]['module_name'],'DynamicService2')
+        self.assertEqual(mods[0]['git_commit_hash'],'29dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(mods[0]['version'],'1.5.0')
+
+        self.assertEqual(mods[1]['module_name'],'DynamicService')
+        self.assertEqual(mods[1]['git_commit_hash'],'49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(mods[1]['version'],'2.1.8')
+
+        # make sure bad tag throws an error
+        with self.assertRaises(ValueError) as e:
+            self.catalog.list_service_modules(self.cUtil.anonymous_ctx(),
+                {'tag':'badtag'})[0]
+        self.assertEqual(str(e.exception),
+            'tag parameter must be either "dev", "beta", or "release".');
+
+
+
+    def test_version_fetch_basics(self):
+
+        # without args should throw an error
+        with self.assertRaises(ValueError) as e:
+            self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {})[0]
+        self.assertEqual(str(e.exception),
+            'Operation failed - module/repo is not registered.');
+
+        # no version given should give last released version
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService'})[0]
+        self.assertEqual(ver['module_name'],'DynamicService')
+        self.assertEqual(ver['git_commit_hash'],'49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(ver['version'],'2.1.8')
 
         ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
-            {'module_name':'DynamicService','only_service_versions':0,'lookup':'>0.0.0,<2.0.0'})[0]
-        print('------')
-        pprint(ver)
+                {'module_name':'DynamicService2'})[0]
+        self.assertEqual(ver['module_name'],'DynamicService2')
+        self.assertEqual(ver['git_commit_hash'],'29dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(ver['version'],'1.5.0')
+
+        # dev works
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService', 'lookup':'dev'})[0]
+        self.assertEqual(ver['module_name'],'DynamicService')
+        self.assertEqual(ver['git_commit_hash'],'b06c5f9daf603a4d206071787c3f6184000bf128')
+        self.assertEqual(ver['version'],'0.0.5')
+
+        # if dev is not a dynamic service, will fail
+        with self.assertRaises(ValueError) as e:
+            ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService2', 'lookup':'dev'})[0]
+        self.assertEqual(str(e.exception),
+            'The "dev" version is not marked as a Service Module.');
+
+        # same thing for beta
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService2', 'lookup':'beta'})[0]
+        self.assertEqual(ver['module_name'],'DynamicService2')
+        self.assertEqual(ver['git_commit_hash'],'39dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(ver['version'],'1.5.1')
+
+        # if dev is not a dynamic service, will fail
+        with self.assertRaises(ValueError) as e:
+            ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService', 'lookup':'beta'})[0]
+        self.assertEqual(str(e.exception),
+            'The "beta" version is not marked as a Service Module.');
+
+        # release works
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService','lookup':'release'})[0]
+        self.assertEqual(ver['module_name'],'DynamicService')
+        self.assertEqual(ver['git_commit_hash'],'49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(ver['version'],'2.1.8')
+
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService2','lookup':'release'})[0]
+        self.assertEqual(ver['module_name'],'DynamicService2')
+        self.assertEqual(ver['git_commit_hash'],'29dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(ver['version'],'1.5.0')
 
 
-    #def test_version_fetch_basics(self):
+        # now the interesting part, getting things by semantic version
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService2','lookup':'==1.5.0'})[0]
+        self.assertEqual(ver['version'],'1.5.0')
 
-    #    version = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),
-    #        {'module_name':'release_history','version':'dev'})[0]
-    #    pprint(version)
-    #    print 'howdy'
+        with self.assertRaises(ValueError) as e:
+            ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService2', 'lookup':'==1.5.1'})[0]
+        self.assertEqual(str(e.exception),
+            'No suitable version matches your lookup.');
+
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService','lookup':'>=1.0.0,<2.0.0'})[0]
+        self.assertEqual(ver['version'],'1.0.2')
+        self.assertEqual(ver['git_commit_hash'],'12edf67800b2923982bdf60c89c57ce6fd2d9a1c')
+        self.assertEqual(ver['module_name'],'DynamicService')
+
+        # if we want a non-service version, we should get the higher bump
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService','lookup':'>=1.0.0,<2.0.0','only_service_versions':1})[0]
+        self.assertEqual(ver['version'],'1.0.2')
+        self.assertEqual(ver['git_commit_hash'],'12edf67800b2923982bdf60c89c57ce6fd2d9a1c')
+        self.assertEqual(ver['module_name'],'DynamicService')
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService','lookup':'>=1.0.0,<2.0.0','only_service_versions':0})[0]
+        self.assertEqual(ver['version'],'1.1.0')
+        self.assertEqual(ver['git_commit_hash'],'d6cd1e2bd19e03a81132a23b2025920577f84e37')
+        self.assertEqual(ver['module_name'],'DynamicService')
+
+        ver = self.catalog.module_version_lookup(self.cUtil.anonymous_ctx(),
+                {'module_name':'DynamicService','lookup':'>2.0.0'})[0]
+        self.assertEqual(ver['version'],'2.1.8')
+        self.assertEqual(ver['git_commit_hash'],'49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(ver['module_name'],'DynamicService')
     
+
 
     @classmethod
     def setUpClass(cls):

--- a/test/initial_mongo_state/modules/dynamic_service.json
+++ b/test/initial_mongo_state/modules/dynamic_service.json
@@ -47,7 +47,7 @@
             "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.b843888e962642d665a3b0bd701ee630c01835e6",
             "git_commit_message" : "update for testing",
             "version" : "0.0.4",
-            "dynamic_service" : 1,
+            "dynamic_service" : 0,
             "narrative_methods" : [
                 "send_data"
             ]
@@ -93,10 +93,10 @@
         },
 
         {
-            "git_commit_hash" : "9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
+            "git_commit_hash" : "12edf67800b2923982bdf60c89c57ce6fd2d9a1c",
             "timestamp" : 1445022815002,
             "registration_id" : "1445022815002_4123",
-            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.9bedf67800b2923982bdf60c89c57ce6fd2d9a1c",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.12edf67800b2923982bdf60c89c57ce6fd2d9a1c",
             "git_commit_message" : "and another thing",
             "version" : "1.0.2",
             "dynamic_service" : 1,

--- a/test/initial_mongo_state/modules/dynamic_service2.json
+++ b/test/initial_mongo_state/modules/dynamic_service2.json
@@ -1,0 +1,80 @@
+{
+    "module_name" : "DynamicService2",
+    "module_name_lc" : "dynamicservice2",
+    "git_url" : "https://github.com/kbaseIncubator/dynamic_service2",
+
+    "info" : {
+        "description" : "KBase module for stuff",
+        "language" : "python",
+        "dynamic_service" : 1
+    },
+
+    "owners" : [
+        {
+            "kb_username" : "new_user"
+        }
+    ],
+
+    "state" : {
+        "active" : true,
+        "error_message" : "",
+        "registration" : "complete",
+        "release_approval" : "approved",
+        "released" : true,
+        "review_message" : ""
+    },
+
+    "current_versions" : {
+        "dev" : {
+            "git_commit_hash" : "19dc505febb8f4cccb2078c58ded0de3320534d7",
+            "timestamp" : 1445022818872,
+            "registration_id" : "1445022818872_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.19dc505febb8f4cccb2078c58ded0de3320534d7",
+            "git_commit_message" : "added",
+            "version" : "1.5.1",
+            "dynamic_service" : 0,
+            "narrative_methods" : [
+                "send_data"
+            ]
+        },
+        "beta" : {
+            "git_commit_hash" : "39dc505febb8f4cccb2078c58ded0de3320534d7",
+            "timestamp" : 1445022818871,
+            "registration_id" : "1445022818871_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.39dc505febb8f4cccb2078c58ded0de3320534d7",
+            "git_commit_message" : "added",
+            "version" : "1.5.1",
+            "dynamic_service" : 1,
+            "narrative_methods" : [
+                "send_data"
+            ]
+        },
+        "release" : {
+            "git_commit_hash" : "29dc505febb8f4cccb2078c58ded0de3320534d7",
+            "timestamp" : 1445022818870,
+            "registration_id" : "1445022818870_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.29dc505febb8f4cccb2078c58ded0de3320534d7",
+            "git_commit_message" : "added",
+            "version" : "1.5.0",
+            "dynamic_service" : 1,
+            "narrative_methods" : [
+                "send_data"
+            ]
+        }
+    },
+
+    "release_version_list" : [
+        {
+            "git_commit_hash" : "29dc505febb8f4cccb2078c58ded0de3320534d7",
+            "timestamp" : 1445022818870,
+            "registration_id" : "1445022818870_4123",
+            "docker_img_name" : "dockerhub-ci.kbase.us/kbase:release_history.29dc505febb8f4cccb2078c58ded0de3320534d7",
+            "git_commit_message" : "added",
+            "version" : "1.5.0",
+            "dynamic_service" : 1,
+            "narrative_methods" : [
+                "get_genomes"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Tests now include coverage of listing service modules and various ways of calling the module version lookup based on release tag or semantic version pattern.  Fixed a minor bug that was uncovered during testing.