### PR TITLE
Fix catalog tests + recompile w/ latest SDK

### DIFF
--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -29,7 +29,7 @@ def _get_token(user_id, password,
                         'grant_type=client_credentials'):
     # This is bandaid helper function until we get a full
     # KBase python auth client released
-    auth = _base64.encodestring(user_id + ':' + password)
+    auth = _base64.b64encode(user_id + ':' + password)
     headers = {'Authorization': 'Basic ' + auth}
     ret = _requests.get(auth_svc, headers=headers, allow_redirects=True)
     status = ret.status_code

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -19,6 +19,10 @@ class Catalog:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     #########################################
+    VERSION = "0.0.1"
+    GIT_URL = "https://github.com/kbase/catalog"
+    GIT_COMMIT_HASH = "2680a67555978f68a050dc52ee7791bae2b89220"
+    
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
 
@@ -37,6 +41,7 @@ class Catalog:
         print('Initialization complete.')
         #END_CONSTRUCTOR
         pass
+    
 
     def version(self, ctx):
         # ctx is the context object
@@ -513,4 +518,11 @@ class Catalog:
             raise ValueError('Method is_admin return value ' +
                              'returnVal is not type int as required.')
         # return the results
+        return [returnVal]
+
+    def status(self, ctx):
+        #BEGIN_STATUS
+        returnVal = {'state': "OK", 'message': "", 'version': self.VERSION, 
+                     'git_url': self.GIT_URL, 'git_commit_hash': self.GIT_COMMIT_HASH}
+        #END_STATUS
         return [returnVal]

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -282,7 +282,7 @@ class JSONRPCServiceCustom(JSONRPCService):
             # Exception was raised inside the method.
             newerr = ServerError()
             newerr.trace = traceback.format_exc()
-            newerr.data = e.__str__()
+            newerr.data = e.message
             raise newerr
         return result
 
@@ -598,6 +598,9 @@ class Application(object):
                              name='Catalog.is_admin',
                              types=[basestring])
         self.method_authentication['Catalog.is_admin'] = 'none'
+        self.rpc_service.add(impl_Catalog.status,
+                             name='Catalog.status',
+                             types=[dict])
         self.auth_client = biokbase.nexus.Client(
             config={'server': 'nexus.api.globusonline.org',
                     'verify_ssl': True,

--- a/test/favorites_test.py
+++ b/test/favorites_test.py
@@ -7,7 +7,7 @@ from pprint import pprint
 
 from catalog_test_util import CatalogTestUtil
 from biokbase.catalog.Impl import Catalog
-
+import time
 
 # tests all the basic get methods
 class BasicCatalogTest(unittest.TestCase):
@@ -40,6 +40,7 @@ class BasicCatalogTest(unittest.TestCase):
         self.assertEqual(favs[0]['id'],'run_megahit')
         self.assertIsNotNone(favs[0]['timestamp'])
 
+        time.sleep(1)  # force different timestamps so sort works
         self.catalog.add_favorite(ctx,
             {'module_name':'MegaHit', 'id':'run_megahit_2'})
         favs2 = self.catalog.list_favorites({}, user)[0]


### PR DESCRIPTION
Test needed a sleep in order to ensure different timestamps

Recompile w/ SDK 1.0.3 (develop branch)