### PR TITLE
Catalog update to improve module version lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ KBase core service to manage app and module information, registration, and relea
 Build status (develop branch):
 [![Build Status](https://travis-ci.org/kbase/catalog.svg)](https://travis-ci.org/kbase/catalog)
 
+#### v2.0.0 - TBA
+  - Major release to support local functions and dynamic services
+  - All old module versions are now preserved and can be retrieved by git commit hash
+  - Module descriptions are now attached to specific module versions instead of to
+    the module itself, so are effectively versioned
+
+
 #### v1.0.4 - 2/26/16
   - Fix for bug with accessible dev-version after registration failure
 

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -4982,6 +4982,11 @@ output has a value which is a Catalog.IOTags
 
 
 
+=item Description
+
+todo: switch release_tag to release_tags
+
+
 =item Definition
 
 =begin html

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -1468,7 +1468,7 @@ FunctionPlace is a reference to a hash where the following keys are defined:
 
 =item Description
 
-
+DEPRECATED!!!  use get_module_version
 
 =back
 
@@ -1646,6 +1646,153 @@ FunctionPlace is a reference to a hash where the following keys are defined:
         Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method list_released_module_versions",
 					    status_line => $self->{client}->status_line,
 					    method_name => 'list_released_module_versions',
+				       );
+    }
+}
+ 
+
+
+=head2 get_module_version
+
+  $version = $obj->get_module_version($selection)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$selection is a Catalog.SelectModuleVersion
+$version is a Catalog.ModuleVersion
+SelectModuleVersion is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	git_url has a value which is a string
+	version has a value which is a string
+	include_module_description has a value which is a Catalog.boolean
+	include_compilation_report has a value which is a Catalog.boolean
+boolean is an int
+ModuleVersion is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	module_description has a value which is a string
+	git_url has a value which is a string
+	released has a value which is a Catalog.boolean
+	release_tags has a value which is a reference to a list where each element is a string
+	timestamp has a value which is an int
+	registration_id has a value which is a string
+	version has a value which is a string
+	git_commit_hash has a value which is a string
+	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
+	narrative_app_ids has a value which is a reference to a list where each element is a string
+	local_function_ids has a value which is a reference to a list where each element is a string
+	docker_img_name has a value which is a string
+	data_folder has a value which is a string
+	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+$selection is a Catalog.SelectModuleVersion
+$version is a Catalog.ModuleVersion
+SelectModuleVersion is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	git_url has a value which is a string
+	version has a value which is a string
+	include_module_description has a value which is a Catalog.boolean
+	include_compilation_report has a value which is a Catalog.boolean
+boolean is an int
+ModuleVersion is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	module_description has a value which is a string
+	git_url has a value which is a string
+	released has a value which is a Catalog.boolean
+	release_tags has a value which is a reference to a list where each element is a string
+	timestamp has a value which is an int
+	registration_id has a value which is a string
+	version has a value which is a string
+	git_commit_hash has a value which is a string
+	git_commit_message has a value which is a string
+	dynamic_service has a value which is a Catalog.boolean
+	narrative_app_ids has a value which is a reference to a list where each element is a string
+	local_function_ids has a value which is a reference to a list where each element is a string
+	docker_img_name has a value which is a string
+	data_folder has a value which is a string
+	data_version has a value which is a string
+	compilation_report has a value which is a Catalog.CompilationReport
+CompilationReport is a reference to a hash where the following keys are defined:
+	sdk_version has a value which is a string
+	sdk_git_commit has a value which is a string
+	impl_file_path has a value which is a string
+	function_places has a value which is a reference to a hash where the key is a string and the value is a Catalog.FunctionPlace
+FunctionPlace is a reference to a hash where the following keys are defined:
+	start_line has a value which is an int
+	end_line has a value which is an int
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub get_module_version
+{
+    my($self, @args) = @_;
+
+# Authentication: none
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function get_module_version (received $n, expecting 1)");
+    }
+    {
+	my($selection) = @args;
+
+	my @_bad_arguments;
+        (ref($selection) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"selection\" (value was \"$selection\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to get_module_version:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'get_module_version');
+	}
+    }
+
+    my $result = $self->{client}->call($self->{url}, $self->{headers}, {
+	method => "Catalog.get_module_version",
+	params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'get_module_version',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_module_version",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'get_module_version',
 				       );
     }
 }
@@ -4584,6 +4731,172 @@ git_url has a value which is a string
 timestamp has a value which is an int
 git_commit_hash has a value which is a string
 version has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 ModuleVersion
+
+=over 4
+
+
+
+=item Description
+
+module_name            - the name of the module
+module_description     - (optionally returned) html description in KBase YAML of this module
+git_url                - the git url of the source for this module
+
+released               - 1 if this version has been released, 0 otherwise
+release_tags           - list of strings of: 'dev', 'beta', or 'release', or empty list
+                         this is a list because the same commit version may be the version in multiple release states
+release_timestamp      - time in ms since epoch when this module was approved and moved to release, null otherwise
+                         note that a module was released before v1.0.0, the release timestamp may not have been
+                         recorded and will default to the registration timestamp
+
+timestamp              - time in ms since epoch when the registration for this version was started
+registration_id        - id of the last registration for this version, used for fetching registration logs and state
+
+version                - validated semantic version number as indicated in the KBase YAML of this version
+                         semantic versions are unique among released versions of this module
+
+git_commit_hash        - the full git commit hash of the source for this module
+git_commit_message     - the message attached to this git commit
+
+dynamic_service        - 1 if this version is available as a web service, 0 otherwise
+
+narrative_app_ids      - list of Narrative App ids registered with this module version
+local_function_ids     - list of Local Function ids registered with this module version
+
+docker_img_name        - name of the docker image for this module created on registration
+data_folder            - name of the data folder used 
+
+compilation_report     - (optionally returned) summary of the KIDL specification compilation
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+module_description has a value which is a string
+git_url has a value which is a string
+released has a value which is a Catalog.boolean
+release_tags has a value which is a reference to a list where each element is a string
+timestamp has a value which is an int
+registration_id has a value which is a string
+version has a value which is a string
+git_commit_hash has a value which is a string
+git_commit_message has a value which is a string
+dynamic_service has a value which is a Catalog.boolean
+narrative_app_ids has a value which is a reference to a list where each element is a string
+local_function_ids has a value which is a reference to a list where each element is a string
+docker_img_name has a value which is a string
+data_folder has a value which is a string
+data_version has a value which is a string
+compilation_report has a value which is a Catalog.CompilationReport
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+module_description has a value which is a string
+git_url has a value which is a string
+released has a value which is a Catalog.boolean
+release_tags has a value which is a reference to a list where each element is a string
+timestamp has a value which is an int
+registration_id has a value which is a string
+version has a value which is a string
+git_commit_hash has a value which is a string
+git_commit_message has a value which is a string
+dynamic_service has a value which is a Catalog.boolean
+narrative_app_ids has a value which is a reference to a list where each element is a string
+local_function_ids has a value which is a reference to a list where each element is a string
+docker_img_name has a value which is a string
+data_folder has a value which is a string
+data_version has a value which is a string
+compilation_report has a value which is a Catalog.CompilationReport
+
+
+=end text
+
+=back
+
+
+
+=head2 SelectModuleVersion
+
+=over 4
+
+
+
+=item Description
+
+Get a specific module version.
+
+Requires either a module_name or git_url.  If both are provided, they both must match.
+
+If no other options are specified, then the latest 'release' version is returned.  If
+the module has not been released, then the latest 'beta' or 'dev' version is returned.
+You can check in the returned object if the version has been released (see is_released)
+and what release tags are pointing to this version (see release_tags).
+
+Optionally, a 'version' parameter can be provided that can be either:
+    1) release tag: 'dev' | 'beta' | 'release'
+
+    2) specific semantic version of a released version (you cannot pull dev/beta or other
+       unreleased versions by semantic version)
+        - e.g. 2.0.1
+
+    3) semantic version requirement specification, see: https://pypi.python.org/pypi/semantic_version/
+       which will return the latest released version that matches the criteria.  You cannot pull
+       dev/beta or other unreleased versions this way.
+        - e.g.:
+            - '>1.0.0'
+            - '>=2.1.1,<3.3.0'
+            - '!=0.2.4-alpha,<0.3.0'
+
+    4) specific full git commit hash
+
+include_module_description - set to 1 to include the module description in the YAML file of this version;
+                             default is 0
+include_compilation_report - set to 1 to include the module compilation report, default is 0
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+git_url has a value which is a string
+version has a value which is a string
+include_module_description has a value which is a Catalog.boolean
+include_compilation_report has a value which is a Catalog.boolean
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+git_url has a value which is a string
+version has a value which is a string
+include_module_description has a value which is a Catalog.boolean
+include_compilation_report has a value which is a Catalog.boolean
 
 
 =end text

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -278,6 +278,13 @@ class Catalog(object):
                           [params], json_rpc_context)
         return resp[0]
   
+    def get_module_version(self, selection, json_rpc_context = None):
+        if json_rpc_context and type(json_rpc_context) is not dict:
+            raise ValueError('Method get_module_version: argument json_rpc_context is not type dict as required.')
+        resp = self._call('Catalog.get_module_version',
+                          [selection], json_rpc_context)
+        return resp[0]
+  
     def list_local_functions(self, params, json_rpc_context = None):
         if json_rpc_context and type(json_rpc_context) is not dict:
             raise ValueError('Method list_local_functions: argument json_rpc_context is not type dict as required.')

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -21,7 +21,7 @@ class Catalog:
     #########################################
     VERSION = "0.0.1"
     GIT_URL = "git@github.com:kbase/catalog.git"
-    GIT_COMMIT_HASH = "013fea039229ac9648259d22a1ffc2c47d37a189"
+    GIT_COMMIT_HASH = "179b9783a506290fac2834da3def4b858b91aba1"
     
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -21,7 +21,7 @@ class Catalog:
     #########################################
     VERSION = "0.0.1"
     GIT_URL = "git@github.com:kbase/catalog.git"
-    GIT_COMMIT_HASH = "f937342d295a43daf6d9795ef6cc8fced06c11c9"
+    GIT_COMMIT_HASH = "013fea039229ac9648259d22a1ffc2c47d37a189"
     
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -236,6 +236,22 @@ class Catalog:
                              'versions is not type list as required.')
         # return the results
         return [versions]
+
+    def get_module_version(self, ctx, selection):
+        # ctx is the context object
+        # return variables are: version
+        #BEGIN get_module_version
+        version = self.cc.get_module_version(selection)
+        if version is None:
+            raise ValueError("No module version found that matches your criteria!")
+        #END get_module_version
+
+        # At some point might do deeper type checking...
+        if not isinstance(version, dict):
+            raise ValueError('Method get_module_version return value ' +
+                             'version is not type dict as required.')
+        # return the results
+        return [version]
 
     def list_local_functions(self, ctx, params):
         # ctx is the context object

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -436,7 +436,7 @@ class CatalogController:
         if 'git_commit_hash' in params:
             # check current versions
             for version in ['dev','beta','release']:
-                if current_version[version]['git_commit_hash'] == params['git_commit_hash']:
+                if 'git_commit_hash' in current_version[version] and current_version[version]['git_commit_hash'] == params['git_commit_hash']:
                     v = current_version[version]
                     return v
             # if we get here, we have to look in full history

--- a/lib/biokbase/catalog/registrar.py
+++ b/lib/biokbase/catalog/registrar.py
@@ -196,7 +196,7 @@ class Registrar:
                 self.set_build_step('pushing docker image to registry')
                 self.push_docker_image(dockerclient,self.image_name)
 
-                #self.log(str(dockerClient.containers()));
+
             else:
                 self.log('IN TEST MODE!! SKIPPING DOCKER BUILD AND DOCKER REGISTRY UPDATE!!')
 
@@ -323,8 +323,6 @@ class Registrar:
         # Combining it into one call would just mean that this update happens as a single transaction, but a partial
         # update for now that fails midstream is probably not a huge issue- we can always reregister.
 
-
-
         # next update the basic information
         info = {
             'description': module_description,
@@ -365,8 +363,12 @@ class Registrar:
                 raise ValueError('There was an error saving local function specs, DB says: '+str(error))
 
         new_version = {
+            'module_name': module_name.strip(),
             'module_name_lc': module_name.strip().lower(),
             'module_description': module_description,
+            'released':0,
+            'released_timestamp':None,
+            'notes': '',
             'timestamp':self.timestamp,
             'registration_id':self.registration_id,
             'version' : version,

--- a/lib/biokbase/catalog/version.py
+++ b/lib/biokbase/catalog/version.py
@@ -1,2 +1,2 @@
 # File that simply defines version information
-CATALOG_VERSION = '1.1.3'
+CATALOG_VERSION = '2.0.0'

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -378,6 +378,7 @@ public class CatalogClient {
     /**
      * <p>Original spec-file function name: get_version_info</p>
      * <pre>
+     * DEPRECATED!!!  use get_module_version
      * </pre>
      * @param   params   instance of type {@link us.kbase.catalog.SelectModuleVersionParams SelectModuleVersionParams}
      * @return   parameter "version" of type {@link us.kbase.catalog.ModuleVersionInfo ModuleVersionInfo}
@@ -406,6 +407,23 @@ public class CatalogClient {
         args.add(params);
         TypeReference<List<List<ModuleVersionInfo>>> retType = new TypeReference<List<List<ModuleVersionInfo>>>() {};
         List<List<ModuleVersionInfo>> res = caller.jsonrpcCall("Catalog.list_released_module_versions", args, retType, true, false, jsonRpcContext);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: get_module_version</p>
+     * <pre>
+     * </pre>
+     * @param   selection   instance of type {@link us.kbase.catalog.SelectModuleVersion SelectModuleVersion}
+     * @return   parameter "version" of type {@link us.kbase.catalog.ModuleVersion ModuleVersion}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public ModuleVersion getModuleVersion(SelectModuleVersion selection, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(selection);
+        TypeReference<List<ModuleVersion>> retType = new TypeReference<List<ModuleVersion>>() {};
+        List<ModuleVersion> res = caller.jsonrpcCall("Catalog.get_module_version", args, retType, true, false, jsonRpcContext);
         return res.get(0);
     }
 

--- a/lib/java/us/kbase/catalog/LocalFunctionDetails.java
+++ b/lib/java/us/kbase/catalog/LocalFunctionDetails.java
@@ -26,7 +26,9 @@ public class LocalFunctionDetails {
 
     /**
      * <p>Original spec-file type: LocalFunctionInfo</p>
-     * 
+     * <pre>
+     * todo: switch release_tag to release_tags
+     * </pre>
      * 
      */
     @JsonProperty("info")
@@ -37,7 +39,9 @@ public class LocalFunctionDetails {
 
     /**
      * <p>Original spec-file type: LocalFunctionInfo</p>
-     * 
+     * <pre>
+     * todo: switch release_tag to release_tags
+     * </pre>
      * 
      */
     @JsonProperty("info")
@@ -47,7 +51,9 @@ public class LocalFunctionDetails {
 
     /**
      * <p>Original spec-file type: LocalFunctionInfo</p>
-     * 
+     * <pre>
+     * todo: switch release_tag to release_tags
+     * </pre>
      * 
      */
     @JsonProperty("info")

--- a/lib/java/us/kbase/catalog/LocalFunctionInfo.java
+++ b/lib/java/us/kbase/catalog/LocalFunctionInfo.java
@@ -13,7 +13,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  * <p>Original spec-file type: LocalFunctionInfo</p>
- * 
+ * <pre>
+ * todo: switch release_tag to release_tags
+ * </pre>
  * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/lib/java/us/kbase/catalog/ModuleVersion.java
+++ b/lib/java/us/kbase/catalog/ModuleVersion.java
@@ -1,0 +1,386 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ModuleVersion</p>
+ * <pre>
+ * module_name            - the name of the module
+ * module_description     - (optionally returned) html description in KBase YAML of this module
+ * git_url                - the git url of the source for this module
+ * released               - 1 if this version has been released, 0 otherwise
+ * release_tags           - list of strings of: 'dev', 'beta', or 'release', or empty list
+ *                          this is a list because the same commit version may be the version in multiple release states
+ * release_timestamp      - time in ms since epoch when this module was approved and moved to release, null otherwise
+ *                          note that a module was released before v1.0.0, the release timestamp may not have been
+ *                          recorded and will default to the registration timestamp
+ * timestamp              - time in ms since epoch when the registration for this version was started
+ * registration_id        - id of the last registration for this version, used for fetching registration logs and state
+ * version                - validated semantic version number as indicated in the KBase YAML of this version
+ *                          semantic versions are unique among released versions of this module
+ * git_commit_hash        - the full git commit hash of the source for this module
+ * git_commit_message     - the message attached to this git commit
+ * dynamic_service        - 1 if this version is available as a web service, 0 otherwise
+ * narrative_app_ids      - list of Narrative App ids registered with this module version
+ * local_function_ids     - list of Local Function ids registered with this module version
+ * docker_img_name        - name of the docker image for this module created on registration
+ * data_folder            - name of the data folder used 
+ * compilation_report     - (optionally returned) summary of the KIDL specification compilation
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "module_name",
+    "module_description",
+    "git_url",
+    "released",
+    "release_tags",
+    "timestamp",
+    "registration_id",
+    "version",
+    "git_commit_hash",
+    "git_commit_message",
+    "dynamic_service",
+    "narrative_app_ids",
+    "local_function_ids",
+    "docker_img_name",
+    "data_folder",
+    "data_version",
+    "compilation_report"
+})
+public class ModuleVersion {
+
+    @JsonProperty("module_name")
+    private java.lang.String moduleName;
+    @JsonProperty("module_description")
+    private java.lang.String moduleDescription;
+    @JsonProperty("git_url")
+    private java.lang.String gitUrl;
+    @JsonProperty("released")
+    private Long released;
+    @JsonProperty("release_tags")
+    private List<String> releaseTags;
+    @JsonProperty("timestamp")
+    private Long timestamp;
+    @JsonProperty("registration_id")
+    private java.lang.String registrationId;
+    @JsonProperty("version")
+    private java.lang.String version;
+    @JsonProperty("git_commit_hash")
+    private java.lang.String gitCommitHash;
+    @JsonProperty("git_commit_message")
+    private java.lang.String gitCommitMessage;
+    @JsonProperty("dynamic_service")
+    private Long dynamicService;
+    @JsonProperty("narrative_app_ids")
+    private List<String> narrativeAppIds;
+    @JsonProperty("local_function_ids")
+    private List<String> localFunctionIds;
+    @JsonProperty("docker_img_name")
+    private java.lang.String dockerImgName;
+    @JsonProperty("data_folder")
+    private java.lang.String dataFolder;
+    @JsonProperty("data_version")
+    private java.lang.String dataVersion;
+    /**
+     * <p>Original spec-file type: CompilationReport</p>
+     * 
+     * 
+     */
+    @JsonProperty("compilation_report")
+    private CompilationReport compilationReport;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("module_name")
+    public java.lang.String getModuleName() {
+        return moduleName;
+    }
+
+    @JsonProperty("module_name")
+    public void setModuleName(java.lang.String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public ModuleVersion withModuleName(java.lang.String moduleName) {
+        this.moduleName = moduleName;
+        return this;
+    }
+
+    @JsonProperty("module_description")
+    public java.lang.String getModuleDescription() {
+        return moduleDescription;
+    }
+
+    @JsonProperty("module_description")
+    public void setModuleDescription(java.lang.String moduleDescription) {
+        this.moduleDescription = moduleDescription;
+    }
+
+    public ModuleVersion withModuleDescription(java.lang.String moduleDescription) {
+        this.moduleDescription = moduleDescription;
+        return this;
+    }
+
+    @JsonProperty("git_url")
+    public java.lang.String getGitUrl() {
+        return gitUrl;
+    }
+
+    @JsonProperty("git_url")
+    public void setGitUrl(java.lang.String gitUrl) {
+        this.gitUrl = gitUrl;
+    }
+
+    public ModuleVersion withGitUrl(java.lang.String gitUrl) {
+        this.gitUrl = gitUrl;
+        return this;
+    }
+
+    @JsonProperty("released")
+    public Long getReleased() {
+        return released;
+    }
+
+    @JsonProperty("released")
+    public void setReleased(Long released) {
+        this.released = released;
+    }
+
+    public ModuleVersion withReleased(Long released) {
+        this.released = released;
+        return this;
+    }
+
+    @JsonProperty("release_tags")
+    public List<String> getReleaseTags() {
+        return releaseTags;
+    }
+
+    @JsonProperty("release_tags")
+    public void setReleaseTags(List<String> releaseTags) {
+        this.releaseTags = releaseTags;
+    }
+
+    public ModuleVersion withReleaseTags(List<String> releaseTags) {
+        this.releaseTags = releaseTags;
+        return this;
+    }
+
+    @JsonProperty("timestamp")
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    @JsonProperty("timestamp")
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public ModuleVersion withTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    @JsonProperty("registration_id")
+    public java.lang.String getRegistrationId() {
+        return registrationId;
+    }
+
+    @JsonProperty("registration_id")
+    public void setRegistrationId(java.lang.String registrationId) {
+        this.registrationId = registrationId;
+    }
+
+    public ModuleVersion withRegistrationId(java.lang.String registrationId) {
+        this.registrationId = registrationId;
+        return this;
+    }
+
+    @JsonProperty("version")
+    public java.lang.String getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(java.lang.String version) {
+        this.version = version;
+    }
+
+    public ModuleVersion withVersion(java.lang.String version) {
+        this.version = version;
+        return this;
+    }
+
+    @JsonProperty("git_commit_hash")
+    public java.lang.String getGitCommitHash() {
+        return gitCommitHash;
+    }
+
+    @JsonProperty("git_commit_hash")
+    public void setGitCommitHash(java.lang.String gitCommitHash) {
+        this.gitCommitHash = gitCommitHash;
+    }
+
+    public ModuleVersion withGitCommitHash(java.lang.String gitCommitHash) {
+        this.gitCommitHash = gitCommitHash;
+        return this;
+    }
+
+    @JsonProperty("git_commit_message")
+    public java.lang.String getGitCommitMessage() {
+        return gitCommitMessage;
+    }
+
+    @JsonProperty("git_commit_message")
+    public void setGitCommitMessage(java.lang.String gitCommitMessage) {
+        this.gitCommitMessage = gitCommitMessage;
+    }
+
+    public ModuleVersion withGitCommitMessage(java.lang.String gitCommitMessage) {
+        this.gitCommitMessage = gitCommitMessage;
+        return this;
+    }
+
+    @JsonProperty("dynamic_service")
+    public Long getDynamicService() {
+        return dynamicService;
+    }
+
+    @JsonProperty("dynamic_service")
+    public void setDynamicService(Long dynamicService) {
+        this.dynamicService = dynamicService;
+    }
+
+    public ModuleVersion withDynamicService(Long dynamicService) {
+        this.dynamicService = dynamicService;
+        return this;
+    }
+
+    @JsonProperty("narrative_app_ids")
+    public List<String> getNarrativeAppIds() {
+        return narrativeAppIds;
+    }
+
+    @JsonProperty("narrative_app_ids")
+    public void setNarrativeAppIds(List<String> narrativeAppIds) {
+        this.narrativeAppIds = narrativeAppIds;
+    }
+
+    public ModuleVersion withNarrativeAppIds(List<String> narrativeAppIds) {
+        this.narrativeAppIds = narrativeAppIds;
+        return this;
+    }
+
+    @JsonProperty("local_function_ids")
+    public List<String> getLocalFunctionIds() {
+        return localFunctionIds;
+    }
+
+    @JsonProperty("local_function_ids")
+    public void setLocalFunctionIds(List<String> localFunctionIds) {
+        this.localFunctionIds = localFunctionIds;
+    }
+
+    public ModuleVersion withLocalFunctionIds(List<String> localFunctionIds) {
+        this.localFunctionIds = localFunctionIds;
+        return this;
+    }
+
+    @JsonProperty("docker_img_name")
+    public java.lang.String getDockerImgName() {
+        return dockerImgName;
+    }
+
+    @JsonProperty("docker_img_name")
+    public void setDockerImgName(java.lang.String dockerImgName) {
+        this.dockerImgName = dockerImgName;
+    }
+
+    public ModuleVersion withDockerImgName(java.lang.String dockerImgName) {
+        this.dockerImgName = dockerImgName;
+        return this;
+    }
+
+    @JsonProperty("data_folder")
+    public java.lang.String getDataFolder() {
+        return dataFolder;
+    }
+
+    @JsonProperty("data_folder")
+    public void setDataFolder(java.lang.String dataFolder) {
+        this.dataFolder = dataFolder;
+    }
+
+    public ModuleVersion withDataFolder(java.lang.String dataFolder) {
+        this.dataFolder = dataFolder;
+        return this;
+    }
+
+    @JsonProperty("data_version")
+    public java.lang.String getDataVersion() {
+        return dataVersion;
+    }
+
+    @JsonProperty("data_version")
+    public void setDataVersion(java.lang.String dataVersion) {
+        this.dataVersion = dataVersion;
+    }
+
+    public ModuleVersion withDataVersion(java.lang.String dataVersion) {
+        this.dataVersion = dataVersion;
+        return this;
+    }
+
+    /**
+     * <p>Original spec-file type: CompilationReport</p>
+     * 
+     * 
+     */
+    @JsonProperty("compilation_report")
+    public CompilationReport getCompilationReport() {
+        return compilationReport;
+    }
+
+    /**
+     * <p>Original spec-file type: CompilationReport</p>
+     * 
+     * 
+     */
+    @JsonProperty("compilation_report")
+    public void setCompilationReport(CompilationReport compilationReport) {
+        this.compilationReport = compilationReport;
+    }
+
+    public ModuleVersion withCompilationReport(CompilationReport compilationReport) {
+        this.compilationReport = compilationReport;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((((((((((((((((((((((((((("ModuleVersion"+" [moduleName=")+ moduleName)+", moduleDescription=")+ moduleDescription)+", gitUrl=")+ gitUrl)+", released=")+ released)+", releaseTags=")+ releaseTags)+", timestamp=")+ timestamp)+", registrationId=")+ registrationId)+", version=")+ version)+", gitCommitHash=")+ gitCommitHash)+", gitCommitMessage=")+ gitCommitMessage)+", dynamicService=")+ dynamicService)+", narrativeAppIds=")+ narrativeAppIds)+", localFunctionIds=")+ localFunctionIds)+", dockerImgName=")+ dockerImgName)+", dataFolder=")+ dataFolder)+", dataVersion=")+ dataVersion)+", compilationReport=")+ compilationReport)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/SelectModuleVersion.java
+++ b/lib/java/us/kbase/catalog/SelectModuleVersion.java
@@ -1,0 +1,155 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: SelectModuleVersion</p>
+ * <pre>
+ * Get a specific module version.
+ * Requires either a module_name or git_url.  If both are provided, they both must match.
+ * If no other options are specified, then the latest 'release' version is returned.  If
+ * the module has not been released, then the latest 'beta' or 'dev' version is returned.
+ * You can check in the returned object if the version has been released (see is_released)
+ * and what release tags are pointing to this version (see release_tags).
+ * Optionally, a 'version' parameter can be provided that can be either:
+ *     1) release tag: 'dev' | 'beta' | 'release'
+ *     2) specific semantic version of a released version (you cannot pull dev/beta or other
+ *        unreleased versions by semantic version)
+ *         - e.g. 2.0.1
+ *     3) semantic version requirement specification, see: https://pypi.python.org/pypi/semantic_version/
+ *        which will return the latest released version that matches the criteria.  You cannot pull
+ *        dev/beta or other unreleased versions this way.
+ *         - e.g.:
+ *             - '>1.0.0'
+ *             - '>=2.1.1,<3.3.0'
+ *             - '!=0.2.4-alpha,<0.3.0'
+ *     4) specific full git commit hash
+ * include_module_description - set to 1 to include the module description in the YAML file of this version;
+ *                              default is 0
+ * include_compilation_report - set to 1 to include the module compilation report, default is 0
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "module_name",
+    "git_url",
+    "version",
+    "include_module_description",
+    "include_compilation_report"
+})
+public class SelectModuleVersion {
+
+    @JsonProperty("module_name")
+    private String moduleName;
+    @JsonProperty("git_url")
+    private String gitUrl;
+    @JsonProperty("version")
+    private String version;
+    @JsonProperty("include_module_description")
+    private Long includeModuleDescription;
+    @JsonProperty("include_compilation_report")
+    private Long includeCompilationReport;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("module_name")
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    @JsonProperty("module_name")
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public SelectModuleVersion withModuleName(String moduleName) {
+        this.moduleName = moduleName;
+        return this;
+    }
+
+    @JsonProperty("git_url")
+    public String getGitUrl() {
+        return gitUrl;
+    }
+
+    @JsonProperty("git_url")
+    public void setGitUrl(String gitUrl) {
+        this.gitUrl = gitUrl;
+    }
+
+    public SelectModuleVersion withGitUrl(String gitUrl) {
+        this.gitUrl = gitUrl;
+        return this;
+    }
+
+    @JsonProperty("version")
+    public String getVersion() {
+        return version;
+    }
+
+    @JsonProperty("version")
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public SelectModuleVersion withVersion(String version) {
+        this.version = version;
+        return this;
+    }
+
+    @JsonProperty("include_module_description")
+    public Long getIncludeModuleDescription() {
+        return includeModuleDescription;
+    }
+
+    @JsonProperty("include_module_description")
+    public void setIncludeModuleDescription(Long includeModuleDescription) {
+        this.includeModuleDescription = includeModuleDescription;
+    }
+
+    public SelectModuleVersion withIncludeModuleDescription(Long includeModuleDescription) {
+        this.includeModuleDescription = includeModuleDescription;
+        return this;
+    }
+
+    @JsonProperty("include_compilation_report")
+    public Long getIncludeCompilationReport() {
+        return includeCompilationReport;
+    }
+
+    @JsonProperty("include_compilation_report")
+    public void setIncludeCompilationReport(Long includeCompilationReport) {
+        this.includeCompilationReport = includeCompilationReport;
+    }
+
+    public SelectModuleVersion withIncludeCompilationReport(Long includeCompilationReport) {
+        this.includeCompilationReport = includeCompilationReport;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((((("SelectModuleVersion"+" [moduleName=")+ moduleName)+", gitUrl=")+ gitUrl)+", version=")+ version)+", includeModuleDescription=")+ includeModuleDescription)+", includeCompilationReport=")+ includeCompilationReport)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -222,6 +222,19 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms, async_ver
             [params], 1, _callback, _errorCallback);
     };
  
+     this.get_module_version = function (selection, _callback, _errorCallback) {
+        if (typeof selection === 'function')
+            throw 'Argument selection can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax("Catalog.get_module_version",
+            [selection], 1, _callback, _errorCallback);
+    };
+ 
      this.list_local_functions = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -260,6 +260,112 @@ class BasicCatalogTest(unittest.TestCase):
         self.assertTrue(info['release'] is None)
 
 
+
+    def test_get_module_version(self):
+
+        # fetch without version info, should return latest release version
+        version = self.catalog.get_module_version(self.cUtil.anonymous_ctx(),
+            {'module_name':'release_history'})[0]
+
+        self.assertEqual(version['timestamp'],1445022818884)
+        self.assertEqual(version['version'],"0.0.3")
+        self.assertEqual(version['narrative_methods'],['send_data'])
+        self.assertEqual(version['local_functions'],[])
+        self.assertEqual(version['module_language'],'python')
+        self.assertEqual(version['module_name'],'release_history')
+        self.assertEqual(version['notes'],'')
+        self.assertEqual(version['registration_id'],'1445022818884_4123')
+        self.assertEqual(version['release_tags'],['release'])
+        self.assertEqual(version['release_timestamp'], 1445022818884)
+        self.assertEqual(version['docker_img_name'],'dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(version['dynamic_service'],0)
+        self.assertEqual(version['git_commit_hash'],"49dc505febb8f4cccb2078c58ded0de3320534d7")
+        self.assertEqual(version['git_commit_message'],"added username for testing")
+        self.assertEqual(version['git_url'],"https://github.com/kbaseIncubator/release_history")
+
+
+        # get a specific tag
+        version = self.catalog.get_module_version(self.cUtil.anonymous_ctx(),
+            {'module_name':'release_history', 'version':'dev', 'include_module_description':0, 'include_compilation_report':0})[0]
+
+        self.assertEqual(version['timestamp'],1445024094055)
+        self.assertEqual(version['version'],"0.0.5")
+        self.assertEqual(version['narrative_methods'],['send_data2'])
+        self.assertEqual(version['local_functions'],[])
+        self.assertEqual(version['module_language'],'python')
+        self.assertEqual(version['module_name'],'release_history')
+        self.assertEqual(version['notes'],'')
+        self.assertEqual(version['registration_id'],'1445024094055_4123')
+        self.assertEqual(version['release_tags'],['dev'])
+        self.assertEqual(version['release_timestamp'], None)
+        self.assertEqual(version['docker_img_name'],'dockerhub-ci.kbase.us/kbase:release_history.b06c5f9daf603a4d206071787c3f6184000bf128')
+        self.assertEqual(version['dynamic_service'],0)
+        self.assertEqual(version['git_commit_hash'],"b06c5f9daf603a4d206071787c3f6184000bf128")
+        self.assertEqual(version['git_commit_message'],"another change")
+        self.assertEqual(version['git_url'],"https://github.com/kbaseIncubator/release_history")
+
+        # get by git commit hash
+        version = self.catalog.get_module_version(self.cUtil.anonymous_ctx(),
+            {'module_name':'release_history', 'version':'49dc505febb8f4cccb2078c58ded0de3320534d7', 'include_module_description':0, 'include_compilation_report':0})[0]
+
+        self.assertEqual(version['timestamp'],1445022818884)
+        self.assertEqual(version['version'],"0.0.3")
+        self.assertEqual(version['narrative_methods'],['send_data'])
+        self.assertEqual(version['local_functions'],[])
+        self.assertEqual(version['module_language'],'python')
+        self.assertEqual(version['module_name'],'release_history')
+        self.assertEqual(version['notes'],'')
+        self.assertEqual(version['registration_id'],'1445022818884_4123')
+        self.assertEqual(version['release_tags'],['release'])
+        self.assertEqual(version['release_timestamp'], 1445022818884)
+        self.assertEqual(version['docker_img_name'],'dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(version['dynamic_service'],0)
+        self.assertEqual(version['git_commit_hash'],"49dc505febb8f4cccb2078c58ded0de3320534d7")
+        self.assertEqual(version['git_commit_message'],"added username for testing")
+        self.assertEqual(version['git_url'],"https://github.com/kbaseIncubator/release_history")
+
+        # get by exact semantic version
+        version = self.catalog.get_module_version(self.cUtil.anonymous_ctx(),
+            {'module_name':'release_history', 'version':'0.0.3', 'include_module_description':0, 'include_compilation_report':0})[0]
+
+        self.assertEqual(version['timestamp'],1445022818884)
+        self.assertEqual(version['version'],"0.0.3")
+        self.assertEqual(version['narrative_methods'],['send_data'])
+        self.assertEqual(version['local_functions'],[])
+        self.assertEqual(version['module_language'],'python')
+        self.assertEqual(version['module_name'],'release_history')
+        self.assertEqual(version['notes'],'')
+        self.assertEqual(version['registration_id'],'1445022818884_4123')
+        self.assertEqual(version['release_tags'],['release'])
+        self.assertEqual(version['release_timestamp'], 1445022818884)
+        self.assertEqual(version['docker_img_name'],'dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(version['dynamic_service'],0)
+        self.assertEqual(version['git_commit_hash'],"49dc505febb8f4cccb2078c58ded0de3320534d7")
+        self.assertEqual(version['git_commit_message'],"added username for testing")
+        self.assertEqual(version['git_url'],"https://github.com/kbaseIncubator/release_history")
+
+
+        # get by semantic version spec
+        version = self.catalog.get_module_version(self.cUtil.anonymous_ctx(),
+            {'module_name':'release_history', 'version':'>0.0.1', 'include_module_description':0, 'include_compilation_report':0})[0]
+
+        self.assertEqual(version['timestamp'],1445022818884)
+        self.assertEqual(version['version'],"0.0.3")
+        self.assertEqual(version['narrative_methods'],['send_data'])
+        self.assertEqual(version['local_functions'],[])
+        self.assertEqual(version['module_language'],'python')
+        self.assertEqual(version['module_name'],'release_history')
+        self.assertEqual(version['notes'],'')
+        self.assertEqual(version['registration_id'],'1445022818884_4123')
+        self.assertEqual(version['release_tags'],['release'])
+        self.assertEqual(version['release_timestamp'], 1445022818884)
+        self.assertEqual(version['docker_img_name'],'dockerhub-ci.kbase.us/kbase:release_history.49dc505febb8f4cccb2078c58ded0de3320534d7')
+        self.assertEqual(version['dynamic_service'],0)
+        self.assertEqual(version['git_commit_hash'],"49dc505febb8f4cccb2078c58ded0de3320534d7")
+        self.assertEqual(version['git_commit_message'],"added username for testing")
+        self.assertEqual(version['git_url'],"https://github.com/kbaseIncubator/release_history")
+
+
     def test_get_version_info(self):
 
         vinfo = self.catalog.get_version_info(self.cUtil.anonymous_ctx(),

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -14,7 +14,7 @@ class BasicCatalogTest(unittest.TestCase):
 
 
     def test_version(self):
-        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['1.1.3'])
+        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['2.0.0'])
 
 
     def test_is_registered(self):

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -174,6 +174,7 @@ class CatalogTestUtil:
     def tearDown(self):
         self.log("tearDown()")
         self.modules.drop()
+        self.module_versions.drop()
         self.local_functions.drop()
         self.developers.drop()
         self.build_logs.drop()

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -45,7 +45,9 @@ class CatalogTestUtil:
         # 2 check that db exists and collections are empty
         self.mongo = MongoClient('mongodb://'+self.test_cfg['mongodb-host'])
         db = self.mongo[self.test_cfg['mongodb-database']]
+        self.db_version = db[MongoCatalogDBI._DB_VERSION]
         self.modules = db[MongoCatalogDBI._MODULES]
+        self.module_versions = db[MongoCatalogDBI._MODULE_VERSIONS]
         self.local_functions = db[MongoCatalogDBI._LOCAL_FUNCTIONS]
         self.developers = db[MongoCatalogDBI._DEVELOPERS]
         self.build_logs = db[MongoCatalogDBI._BUILD_LOGS]
@@ -57,7 +59,9 @@ class CatalogTestUtil:
         self.exec_stats_users = db[MongoCatalogDBI._EXEC_STATS_USERS]
 
         # just drop the test db
+        self.db_version.drop()
         self.modules.drop()
+        self.module_versions.drop()
         self.local_functions.drop()
         self.developers.drop()
         self.build_logs.drop()

--- a/test/core_registration_test.py
+++ b/test/core_registration_test.py
@@ -426,7 +426,7 @@ class CoreRegistrationTest(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             self.catalog.request_release(self.cUtil.user_ctx(),{'module_name':info['module_name']})
         self.assertEqual(str(e.exception),
-            'Cannot request release - beta version semantic version must be greater than the released version semantic version, as determined by http://semver.org')
+            'Cannot request release - beta semantic version (0.0.1) must be greater than the released semantic version 0.0.2, as determined by http://semver.org')
 
 
         # Register with a proper version number and indicate it is a dynamic service now


### PR DESCRIPTION
This PR introduces a fairly substantial change to the catalog internals for several reasons:
1) We want to be able to store old discarded dev/beta versions and look them up by git commit hash so that they are rerunnable even after dev/beta versions are updated
2) We want a more flexible and general way to fetch specific module version information by git commit hash, semantic version, dev/beta/release tags, or the latest release by default
3) We want better access to the compilation report for a specific module version

This PR will support necessary changes for data<->files and local function work, and for better UI for local functions.  The changes also make the underlying catalog a bit more stable.  Despite the major version bump, the API is actually backwards compatible for now, although we can now start removing some calls from NJS or kb-sdk in favor of the new get_module_version method.
