### PR TITLE
Allow admin to register any module

### DIFF
--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -180,7 +180,7 @@ class CatalogController:
 
         # first set the dev current_release timestamp
 
-        t = threading.Thread(target=_start_registration, args=(params,registration_id,timestamp,username,token,self.db, self.temp_dir, self.docker_base_url, 
+        t = threading.Thread(target=_start_registration, args=(params,registration_id,timestamp,username,self.is_admin(username),token,self.db, self.temp_dir, self.docker_base_url, 
             self.docker_registry_host, self.docker_push_allow_insecure, self.nms_url, self.nms_admin_user, self.nms_admin_psswd, module_details, self.ref_data_base, self.kbase_endpoint,
             prev_dev_version))
         t.start()
@@ -1436,10 +1436,10 @@ class CatalogController:
 
 
 # NOT PART OF CLASS CATALOG!!
-def _start_registration(params,registration_id, timestamp,username,token, db, temp_dir, docker_base_url, docker_registry_host,
+def _start_registration(params,registration_id, timestamp,username,is_admin,token, db, temp_dir, docker_base_url, docker_registry_host,
                         docker_push_allow_insecure,
                         nms_url, nms_admin_user, nms_admin_psswd, module_details, ref_data_base, kbase_endpoint, prev_dev_version):
-    registrar = Registrar(params, registration_id, timestamp, username, token, db, temp_dir, docker_base_url, docker_registry_host,
+    registrar = Registrar(params, registration_id, timestamp, username, is_admin,token, db, temp_dir, docker_base_url, docker_registry_host,
                             docker_push_allow_insecure, 
                             nms_url, nms_admin_user, nms_admin_psswd, module_details, ref_data_base, kbase_endpoint, prev_dev_version)
     registrar.start_registration()

--- a/lib/biokbase/catalog/registrar.py
+++ b/lib/biokbase/catalog/registrar.py
@@ -284,7 +284,7 @@ class Registrar:
         self.db.set_build_log_module_name(self.registration_id, module_name)
 
         # you can't remove yourself from the owners list, or register something that you are not an owner of
-        if self.username not in owners and is_admin is False:
+        if self.username not in owners and self.is_admin is False:
             raise ValueError('Your kbase username ('+self.username+') must be in the owners list in the kbase.yaml file.')
 
         # OPTIONAL TODO: check if all the users are on the owners list?  not necessarily required, because we

--- a/lib/biokbase/catalog/registrar.py
+++ b/lib/biokbase/catalog/registrar.py
@@ -28,7 +28,7 @@ class Registrar:
 
     # params is passed in from the controller, should be the same as passed into the spec
     # db is a reference to the Catalog DB interface (usually a MongoCatalogDBI instance)
-    def __init__(self, params, registration_id, timestamp, username, token, db, temp_dir, docker_base_url, 
+    def __init__(self, params, registration_id, timestamp, username, is_admin,token, db, temp_dir, docker_base_url, 
                     docker_registry_host, docker_push_allow_insecure, nms_url, nms_admin_user, nms_admin_psswd, module_details,
                     ref_data_base, kbase_endpoint, prev_dev_version):
         self.db = db
@@ -39,6 +39,7 @@ class Registrar:
         self.registration_id = registration_id
         self.timestamp = timestamp
         self.username = username
+        self.is_admin = is_admin
         self.token = token
         self.db = db
         self.temp_dir = temp_dir
@@ -283,7 +284,7 @@ class Registrar:
         self.db.set_build_log_module_name(self.registration_id, module_name)
 
         # you can't remove yourself from the owners list, or register something that you are not an owner of
-        if self.username not in owners:
+        if self.username not in owners and is_admin is False:
             raise ValueError('Your kbase username ('+self.username+') must be in the owners list in the kbase.yaml file.')
 
         # OPTIONAL TODO: check if all the users are on the owners list?  not necessarily required, because we


### PR DESCRIPTION
This changes allows an admin to register modules owned by others.  This is useful if we are initializing a fresh install and want to populate the catalog with methods without requiring the owners to register them.  This will also be useful if we need push an update for special reasons.