### PR TITLE
Fixed travis tests!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,12 @@ python:
     - '2.7'
 services:
     - docker
-    # Note that we need to install mongodb manually for now because the built-in mongo
-    # service in travis is not compatible with the image we need to run docker
 
 before_install:
-    # list docker-engine versions
-    - apt-cache madison docker-engine
-    # upgrade docker-engine to specific version
-    - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
-    - docker version
-    # get and install mongodb
-    - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
-    - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz
-    - export PATH=`pwd`/mongodb-linux-x86_64-$MONGODB_VERSION/bin:$PATH
-    - mkdir -p mongodata/db
-    - mongod --dbpath=mongodata/db --fork --logpath /dev/null
+    #- docker run -d -p 5000:5000 --name registry registry:2
+    - docker run -p 27017:27017 --name mongo2.7 -d mongo:2.7
     - sleep 3
     - mongo --eval "printjson(db.serverStatus())"
-    - javac -version
-    - java -version
 
 install:
     - pip install -r travis_requirements.txt
@@ -51,5 +38,4 @@ after_success:
 env:
   global:
     - secure: "wYp9dN9eMga877iX8TUbO6AN/oMUpsmoVmcmNhUup1D/uMrPF1g2nqqKADV9APcuM1fu7t60nV3NdjyiZByc1YpWVeBYKKLheV6xosLKw1N7T62Ksb1euFSvVAX6OEmr+eaUTTSXwtrHyYhutgL/IWeiqanJRBBH1L7p5M7SJZTOhAtmW+/RElASwmPBxVQCY6vrehUcJ+2H49RnhQPc1ZD1c+favJfl4FMJ2MuYhvD+YBEY+GRyA8yYI46EwXUXitm2/ER24xl2/yggtiwIVC15k7ZH6DjuwXiem2QsMHhZTA38Kahh3YeB+MJAb5uJ4OCIKn04vfZEg/0rNHWcW5sAveI8ogRFtgYXcm/bB1tI7idvJI/87oz9sqqesUgi8/smMyTsERywU3D87VR4Yuh5SJXGWqLpqdmXlXHZTKaUc6YAlus2CyURz2gJjzGKOLc5craNN7Bxz00DluyfcBRYRErEDB8IJldWhxXwgFEsvmlQ9bwquvZsucNg51AsR7fnTY42trY4UDOi2Zvg2G6Wf0oXrkEitxLwD7vjjOmP8lTA+C2wwrUWmgceBNd9o0wNmEEIvhMe3GDAqySznGJALbl1xnuQEXO9ChyZAluDOKi212dtT2hDEa59Mha+A1AiIsp5xmwv+as/vAXv9aOZ+lp1ncdOHr5VMH02/kE="
-    - MONGODB_VERSION=2.6.10
-    - DOCKER_VERSION=1.10.1-0~trusty
+    - MONGODB_VERSION=2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
     - git clone https://github.com/kbase/jars
     - git clone https://github.com/kbase/kb_sdk
     - cd kb_sdk
+    - git checkout 9b628a9
     - make
     - make sdkbase
     - docker images


### PR DESCRIPTION
Turned out to be a little easier than expected.  The updates from Travis actually made it possible to run the latest version of docker, and just start mongo through docker (rather than originally using the travis built-in mongo service and updating to a specific versions to get it all to work)