### PR TITLE
Version bump to 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ develop: [![Build Status](https://travis-ci.org/kbase/catalog.svg?branch=develop
 Code coverage: (develop branch)
 [![Coverage Status](https://coveralls.io/repos/github/kbase/catalog/badge.svg?branch=develop)](https://coveralls.io/github/kbase/catalog?branch=develop)
 
+#### v2.1.0 - 4/13/17
+  - No change from 2.0.7, but upgraded minor version number because many new features
+    now exist since the initial 2.0.x release.
+
 #### v2.0.7 - 3/28/17
   - Added job_id field to raw execution statistics
   - Support for hidden configuration parameters

--- a/lib/biokbase/catalog/version.py
+++ b/lib/biokbase/catalog/version.py
@@ -1,2 +1,2 @@
 # File that simply defines version information
-CATALOG_VERSION = '2.0.7'
+CATALOG_VERSION = '2.1.0'

--- a/test/basic_catalog_test.py
+++ b/test/basic_catalog_test.py
@@ -14,7 +14,7 @@ class BasicCatalogTest(unittest.TestCase):
 
 
     def test_version(self):
-        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['2.0.7'])
+        self.assertEqual(self.catalog.version(self.cUtil.anonymous_ctx()),['2.1.0'])
 
 
     def test_is_registered(self):


### PR DESCRIPTION
There were enough changes over the last several patch versions updates that I think justify having a new minor version.