### PR TITLE
SCT-1777: Auth roles

### DIFF
--- a/catalog.spec
+++ b/catalog.spec
@@ -782,7 +782,7 @@ module Catalog {
                 returns (list<VolumeMountConfig> volume_mount_configs) authentication required;
 
     /* returns true (1) if the user is an admin, false (0) otherwise */
-    funcdef is_admin(string username) returns (boolean); 
+    funcdef is_admin() returns (boolean) authentication required;
 
     /*
         version - optional version (commit hash, tag or semantic one) of module, if not set

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -14,17 +14,13 @@ mongodb-database = catalog
 
 # The KBase auth server url.
 auth-service-url = https://kbase.us/services/authorization/Sessions/Login
+admin-roles = KBASE_ADMIN,CATALOG_ADMIN
 
 # Path to docker socket/host
 docker-base-url = unix://var/run/docker.sock
 # for tcp: "tcp://host:port"
 # Docker registry to use
 docker-registry-host = dockerhub-ci.kbase.us
-
-admin-roles = KBASE_ADMIN,CATALOG_ADMIN
-# Users (kbase account username) that can review/approve/disable modules and releases.
-# Multiple admin users can be specified as a comma delimited list
-admin-users = 
 
 # Temporary working directory for checking out repos and doing stuff
 temp-dir = 

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -21,6 +21,7 @@ docker-base-url = unix://var/run/docker.sock
 # Docker registry to use
 docker-registry-host = dockerhub-ci.kbase.us
 
+admin-roles = KBASE_ADMIN,CATALOG_ADMIN
 # Users (kbase account username) that can review/approve/disable modules and releases.
 # Multiple admin users can be specified as a comma delimited list
 admin-users = 

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -4658,7 +4658,7 @@ boolean is an int
 
 =head2 is_admin
 
-  $return = $obj->is_admin($username)
+  $return = $obj->is_admin()
 
 =over 4
 
@@ -4667,7 +4667,6 @@ boolean is an int
 =begin html
 
 <pre>
-$username is a string
 $return is a Catalog.boolean
 boolean is an int
 
@@ -4677,7 +4676,6 @@ boolean is an int
 
 =begin text
 
-$username is a string
 $return is a Catalog.boolean
 boolean is an int
 
@@ -4696,23 +4694,12 @@ returns true (1) if the user is an admin, false (0) otherwise
 {
     my($self, @args) = @_;
 
-# Authentication: none
+# Authentication: required
 
-    if ((my $n = @args) != 1)
+    if ((my $n = @args) != 0)
     {
 	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-							       "Invalid argument count for function is_admin (received $n, expecting 1)");
-    }
-    {
-	my($username) = @args;
-
-	my @_bad_arguments;
-        (!ref($username)) or push(@_bad_arguments, "Invalid type for argument 1 \"username\" (value was \"$username\")");
-        if (@_bad_arguments) {
-	    my $msg = "Invalid arguments passed to is_admin:\n" . join("", map { "\t$_\n" } @_bad_arguments);
-	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
-								   method_name => 'is_admin');
-	}
+							       "Invalid argument count for function is_admin (received $n, expecting 0)");
     }
 
     my $url = $self->{url};

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -954,14 +954,13 @@ class Catalog(object):
         return self._client.call_method('Catalog.list_volume_mounts',
                                         [filter], self._service_ver, context)
 
-    def is_admin(self, username, context=None):
+    def is_admin(self, context=None):
         """
         returns true (1) if the user is an admin, false (0) otherwise
-        :param username: instance of String
         :returns: instance of type "boolean" (@range [0,1])
         """
         return self._client.call_method('Catalog.is_admin',
-                                        [username], self._service_ver, context)
+                                        [], self._service_ver, context)
 
     def set_secure_config_params(self, params, context=None):
         """

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -21,7 +21,7 @@ class Catalog:
     ######################################### noqa
     VERSION = "0.0.1"
     GIT_URL = "https://github.com/kbase/catalog.git"
-    GIT_COMMIT_HASH = "83fec5967d709dadf8b7592e98e5b49a2b2cc1e9"
+    GIT_COMMIT_HASH = "45437dca268d2b42cabf1850666fa9da125cf3a2"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -41,6 +41,7 @@ class Catalog:
         print('Initialization complete.')
         #END_CONSTRUCTOR
         pass
+
 
     def version(self, ctx):
         """
@@ -1335,20 +1336,18 @@ class Catalog:
         # return the results
         return [volume_mount_configs]
 
-    def is_admin(self, ctx, username):
+    def is_admin(self, ctx):
         """
         returns true (1) if the user is an admin, false (0) otherwise
-        :param username: instance of String
         :returns: instance of type "boolean" (@range [0,1])
         """
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN is_admin
-        returnVal = 0
-        if username and username != ctx.get('user_id'):
-            raise ValueError("Can only check on own admin status")
         if self.cc.is_admin(ctx.get('user_id'), ctx.get('token')):
             returnVal = 1
+        else:
+            returnVal = 0
         #END is_admin
 
         # At some point might do deeper type checking...

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 #BEGIN_HEADER
-from pprint import pprint
 from biokbase.catalog.controller import CatalogController
 #END_HEADER
 
@@ -42,7 +41,6 @@ class Catalog:
         print('Initialization complete.')
         #END_CONSTRUCTOR
         pass
-
 
     def version(self, ctx):
         """
@@ -105,7 +103,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: registration_id
         #BEGIN register_repo
-        registration_id = self.cc.register_repo(params, ctx['user_id'], ctx['token'])
+        registration_id = self.cc.register_repo(params, ctx.get('user_id'), ctx.get('token'))
         #END register_repo
 
         # At some point might do deeper type checking...
@@ -127,7 +125,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN push_dev_to_beta
-        self.cc.push_dev_to_beta(params,ctx['user_id'])
+        self.cc.push_dev_to_beta(params, ctx.get('user_id'), ctx.get('token'))
         #END push_dev_to_beta
         pass
 
@@ -142,7 +140,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN request_release
-        self.cc.request_release(params,ctx['user_id'])
+        self.cc.request_release(params, ctx.get('user_id'), ctx.get('token'))
         #END request_release
         pass
 
@@ -176,7 +174,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN review_release_request
-        self.cc.review_release_request(review, ctx['user_id'])
+        self.cc.review_release_request(review,  ctx.get('user_id'), ctx.get('token'))
         #END review_release_request
         pass
 
@@ -233,7 +231,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN add_favorite
-        self.cc.add_favorite(params,ctx['user_id'])
+        self.cc.add_favorite(params, ctx.get('user_id'), ctx.get('token'))
         #END add_favorite
         pass
 
@@ -245,7 +243,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN remove_favorite
-        self.cc.remove_favorite(params,ctx['user_id'])
+        self.cc.remove_favorite(params, ctx.get('user_id'), ctx.get('token'))
         #END remove_favorite
         pass
 
@@ -259,7 +257,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: favorites
         #BEGIN list_favorites
-        favorites = self.cc.list_user_favorites(username)
+        favorites = self.cc.list_user_favorites(username, ctx.get('token'))
         #END list_favorites
 
         # At some point might do deeper type checking...
@@ -818,7 +816,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN set_registration_state
-        self.cc.set_registration_state(params, ctx['user_id'])
+        self.cc.set_registration_state(params,  ctx.get('user_id'), ctx.get('token'))
         #END set_registration_state
         pass
 
@@ -960,7 +958,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN delete_module
-        self.cc.delete_module(params,ctx['user_id'])
+        self.cc.delete_module(params, ctx.get('user_id'), ctx.get('token'))
         #END delete_module
         pass
 
@@ -977,7 +975,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN migrate_module_to_new_git_url
-        self.cc.migrate_module_to_new_git_url(params,ctx['user_id'])
+        self.cc.migrate_module_to_new_git_url(params, ctx.get('user_id'), ctx.get('token'))
         #END migrate_module_to_new_git_url
         pass
 
@@ -992,7 +990,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN set_to_active
-        self.cc.set_module_active_state(True, params, ctx['user_id'])
+        self.cc.set_module_active_state(True, params,  ctx.get('user_id'), ctx.get('token'))
         #END set_to_active
         pass
 
@@ -1006,7 +1004,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN set_to_inactive
-        self.cc.set_module_active_state(False, params, ctx['user_id'])
+        self.cc.set_module_active_state(False, params,  ctx.get('user_id'), ctx.get('token'))
         #END set_to_inactive
         pass
 
@@ -1058,7 +1056,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN approve_developer
-        usernames = self.cc.approve_developer(username, ctx['user_id'])
+        usernames = self.cc.approve_developer(username,  ctx.get('user_id'), ctx.get('token'))
         #END approve_developer
         pass
 
@@ -1068,7 +1066,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN revoke_developer
-        usernames = self.cc.revoke_developer(username, ctx['user_id'])
+        usernames = self.cc.revoke_developer(username,  ctx.get('user_id'), ctx.get('token'))
         #END revoke_developer
         pass
 
@@ -1099,21 +1097,19 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN log_exec_stats
-        admin_user_id = ctx['user_id']
-        if not self.cc.is_admin(admin_user_id):
-            raise ValueError('You do not have permission to log execution statistics.')
-        user_id = params['user_id']
-        app_module_name = None if 'app_module_name' not in params else params['app_module_name']
-        app_id = None if 'app_id' not in params else params['app_id']
-        func_module_name = None if 'func_module_name' not in params else params['func_module_name']
-        func_name = params['func_name']
-        git_commit_hash = None if 'git_commit_hash' not in params else params['git_commit_hash']
-        creation_time = params['creation_time']
-        exec_start_time = params['exec_start_time']
-        finish_time = params['finish_time']
-        is_error = params['is_error'] != 0
+        admin_user_id = ctx.get('user_id')
+        user_id = params.get('user_id')
+        app_module_name = params.get('app_module_name')
+        app_id = params.get('app_id')
+        func_module_name = params.get('func_module_name')
+        func_name = params.get('func_name')
+        git_commit_hash = params.get('git_commit_hash')
+        creation_time = params.get('creation_time')
+        exec_start_time = params.get('exec_start_time')
+        finish_time = params.get('finish_time')
+        is_error = params.get('is_error') != 0
         job_id = params.get('job_id')
-        self.cc.log_exec_stats(admin_user_id, user_id, app_module_name, app_id, func_module_name,
+        self.cc.log_exec_stats(admin_user_id, ctx.get('token'), user_id, app_module_name, app_id, func_module_name,
                                func_name, git_commit_hash, creation_time, exec_start_time, 
                                finish_time, is_error, job_id)
         #END log_exec_stats
@@ -1169,7 +1165,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: table
         #BEGIN get_exec_aggr_table
-        table = self.cc.get_exec_aggr_table(ctx['user_id'], params)
+        table = self.cc.get_exec_aggr_table(ctx.get('user_id'), ctx.get('token'), params)
         #END get_exec_aggr_table
 
         # At some point might do deeper type checking...
@@ -1189,7 +1185,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: records
         #BEGIN get_exec_raw_stats
-        records = self.cc.get_exec_raw_stats(ctx['user_id'], params)
+        records = self.cc.get_exec_raw_stats(ctx.get('user_id'), ctx.get('token'), params)
         #END get_exec_raw_stats
 
         # At some point might do deeper type checking...
@@ -1232,7 +1228,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN set_client_group_config
-        self.cc.set_client_group_config(ctx['user_id'], config)
+        self.cc.set_client_group_config(ctx.get('user_id'), ctx.get('token'), config)
         #END set_client_group_config
         pass
 
@@ -1244,7 +1240,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN remove_client_group_config
-        self.cc.remove_client_group_config(ctx['user_id'], config)
+        self.cc.remove_client_group_config(ctx.get('user_id'), ctx.get('token'), config)
         #END remove_client_group_config
         pass
 
@@ -1284,7 +1280,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN set_volume_mount
-        self.cc.set_volume_mount(ctx['user_id'], config)
+        self.cc.set_volume_mount(ctx.get('user_id'), ctx.get('token'), config)
         #END set_volume_mount
         pass
 
@@ -1302,7 +1298,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN remove_volume_mount
-        self.cc.remove_volume_mount(ctx['user_id'], config)
+        self.cc.remove_volume_mount(ctx.get('user_id'), ctx.get('token'), config)
         #END remove_volume_mount
         pass
 
@@ -1329,7 +1325,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: volume_mount_configs
         #BEGIN list_volume_mounts
-        volume_mount_configs = self.cc.list_volume_mounts(ctx['user_id'], filter)
+        volume_mount_configs = self.cc.list_volume_mounts(ctx.get('user_id'), ctx.get('token'), filter)
         #END list_volume_mounts
 
         # At some point might do deeper type checking...
@@ -1349,9 +1345,10 @@ class Catalog:
         # return variables are: returnVal
         #BEGIN is_admin
         returnVal = 0
-        if username:
-            if self.cc.is_admin(username):
-                returnVal = 1
+        if username and username != ctx.get('user_id'):
+            raise ValueError("Can only check on own admin status")
+        if self.cc.is_admin(ctx.get('user_id'), ctx.get('token')):
+            returnVal = 1
         #END is_admin
 
         # At some point might do deeper type checking...
@@ -1377,7 +1374,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN set_secure_config_params
-        self.cc.set_secure_config_params(ctx.get('user_id'), params)
+        self.cc.set_secure_config_params(ctx.get('user_id'), ctx.get('token'), params)
         #END set_secure_config_params
         pass
 
@@ -1397,7 +1394,7 @@ class Catalog:
         """
         # ctx is the context object
         #BEGIN remove_secure_config_params
-        self.cc.remove_secure_config_params(ctx.get('user_id'), params)
+        self.cc.remove_secure_config_params(ctx.get('user_id'), ctx.get('token'), params)
         #END remove_secure_config_params
         pass
 
@@ -1424,7 +1421,7 @@ class Catalog:
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN get_secure_config_params
-        returnVal = self.cc.get_secure_config_params(ctx.get('user_id'), params)
+        returnVal = self.cc.get_secure_config_params(ctx.get('user_id'), ctx.get('token'), params)
         #END get_secure_config_params
 
         # At some point might do deeper type checking...

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -520,8 +520,8 @@ class Application(object):
         self.method_authentication['Catalog.list_volume_mounts'] = 'required'  # noqa
         self.rpc_service.add(impl_Catalog.is_admin,
                              name='Catalog.is_admin',
-                             types=[str])
-        self.method_authentication['Catalog.is_admin'] = 'none'  # noqa
+                             types=[])
+        self.method_authentication['Catalog.is_admin'] = 'required'  # noqa
         self.rpc_service.add(impl_Catalog.set_secure_config_params,
                              name='Catalog.set_secure_config_params',
                              types=[dict])

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from urllib.parse import urlparse
 
 import semantic_version
+import requests
 
 import biokbase.catalog.version
 from biokbase.catalog.db import MongoCatalogDBI
@@ -20,6 +21,8 @@ class CatalogController:
 
         # first grab the admin list
         self.adminList = []
+        self.auth_url = config['auth-service-url']
+        self.admin_roles = config.get('admin-roles', "").split(',')
         if 'admin-users' in config:
             tokens = config['admin-users'].split(',')
             for t in tokens:
@@ -142,12 +145,12 @@ class CatalogController:
             module_details = self.db.get_module_full_details(git_url=git_url)
 
         # 2) If it has already been registered, make sure the user has permissions to update, and
-        # that the module is in a state where it can be registered 
+        # that the module is in a state where it can be registered
         else:
             module_details = self.db.get_module_full_details(git_url=git_url)
 
             # 2a) Make sure the user has permission to register this URL
-            if self.has_permission(username, module_details['owners']):
+            if self.has_permission(username, token, module_details['owners']):
                 # 2b) Make sure the current registration state is either 'complete' or 'error',
                 # and the module is active
                 state = module_details['state']
@@ -190,19 +193,19 @@ class CatalogController:
         # first set the dev current_release timestamp
 
         t = threading.Thread(target=_start_registration, args=(
-        params, registration_id, timestamp, username, self.is_admin(username), token, self.db,
+        params, registration_id, timestamp, username, self.is_admin(username, token), token, self.db,
         self.temp_dir, self.docker_base_url,
         self.docker_registry_host, self.nms_url, self.nms_token, module_details,
         self.ref_data_base, self.kbase_endpoint,
         prev_dev_version))
         t.start()
 
-        # 4) provide the registration_id 
+        # 4) provide the registration_id
         return registration_id
 
-    def set_registration_state(self, params, username):
+    def set_registration_state(self, params, username, token):
         # first some error handling
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError(
                 'You do not have permission to modify the registration state of this module/repo.')
         params = self.filter_module_or_repo_selection(params)
@@ -230,7 +233,7 @@ class CatalogController:
             raise ValueError(
                 'Registration failed for git repo - some unknown database error: ' + error)
 
-    def push_dev_to_beta(self, params, username):
+    def push_dev_to_beta(self, params, username, token):
         # first make sure everything exists and we have permissions
         params = self.filter_module_or_repo_selection(params)
         module_details = self.db.get_module_details(module_name=params['module_name'],
@@ -239,7 +242,7 @@ class CatalogController:
         if not self.is_approved_developer([username])[0]:
             raise ValueError('You are not an approved developer.  Contact us to request approval.')
 
-        if not self.has_permission(username, module_details['owners']):
+        if not self.has_permission(username, token, module_details['owners']):
             raise ValueError('You do not have permission to modify this module/repo.')
         # next make sure the state of the module is ok (it must be active, no pending
         # registrations or release requests)
@@ -258,7 +261,7 @@ class CatalogController:
         if error is not None:
             raise ValueError('Update operation failed - some unknown database error: ' + error)
 
-    def request_release(self, params, username):
+    def request_release(self, params, username, token):
         # first make sure everything exists and we have permissions
         params = self.filter_module_or_repo_selection(params)
         module_details = self.db.get_module_details(module_name=params['module_name'],
@@ -266,7 +269,7 @@ class CatalogController:
         # Make sure the submitter is still an approved developer
         if not self.is_approved_developer([username])[0]:
             raise ValueError('You are not an approved developer.  Contact us to request approval.')
-        if not self.has_permission(username, module_details['owners']):
+        if not self.has_permission(username, token, module_details['owners']):
             raise ValueError('You do not have permission to modify this module/repo.')
         # next make sure the state of the module is ok (it must be active, no pending release requests)
         if not module_details['state']['active']:
@@ -332,8 +335,8 @@ class CatalogController:
             })
         return requested_releases
 
-    def review_release_request(self, review, username):
-        if not self.is_admin(username):
+    def review_release_request(self, review, username, token):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to review a release request.')
         review = self.filter_module_or_repo_selection(review)
 
@@ -359,7 +362,7 @@ class CatalogController:
         if review['decision'] not in ['approved', 'denied']:
             raise ValueError('Cannot set review - decision must be "approved" or "denied"')
 
-        # ok, do it.  
+        # ok, do it.
 
         # if the state is approved, then we need to save the beta version over the release version and stash
         # a new entry.  The DBI will handle that for us. (note that concurency issues don't really matter
@@ -800,9 +803,9 @@ class CatalogController:
 
         return self.db.get_local_function_spec(params['functions'])
 
-    def set_module_active_state(self, active, params, username):
+    def set_module_active_state(self, active, params, username, token):
         params = self.filter_module_or_repo_selection(params)
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('Only Admin users can set a module to be active/inactive.')
         module_details = self.db.get_module_details(module_name=params['module_name'],
                                                     git_url=params['git_url'])
@@ -818,21 +821,21 @@ class CatalogController:
         else:
             self.nms.enable_repo({'module_name': module_details['module_name']})
 
-    def approve_developer(self, developer, username):
+    def approve_developer(self, developer, username, token):
         if not developer:
             raise ValueError('No username provided')
         if not developer.strip():
             raise ValueError('No username provided')
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('Only Admin users can approve or revoke developers.')
         self.db.approve_developer(developer)
 
-    def revoke_developer(self, developer, username):
+    def revoke_developer(self, developer, username, token):
         if not developer:
             raise ValueError('No username provided')
         if not developer.strip():
             raise ValueError('No username provided')
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('Only Admin users can approve or revoke developers.')
         self.db.revoke_developer(developer)
 
@@ -930,8 +933,8 @@ class CatalogController:
             only_complete=only_complete
         )
 
-    def delete_module(self, params, username):
-        if not self.is_admin(username):
+    def delete_module(self, params, username, token):
+        if not self.is_admin(username, token):
             raise ValueError('Only Admin users can delete modules.')
         if 'module_name' not in params and 'git_url' not in params:
             raise ValueError(
@@ -944,8 +947,8 @@ class CatalogController:
             raise ValueError('Delete operation failed - some unknown database error: ' + error)
         self.nms.disable_repo({'module_name': module_details['module_name']})
 
-    def migrate_module_to_new_git_url(self, params, username):
-        if not self.is_admin(username):
+    def migrate_module_to_new_git_url(self, params, username, token):
+        if not self.is_admin(username, token):
             raise ValueError('Only Admin users can migrate module git urls.')
         if 'module_name' not in params:
             raise ValueError('You must specify the "module_name" of the module to modify.')
@@ -961,7 +964,7 @@ class CatalogController:
         if error is not None:
             raise ValueError('Update operation failed - some unknown database error: ' + error)
 
-    def add_favorite(self, params, username):
+    def add_favorite(self, params, username, token):
         timestamp = int((datetime.utcnow() - datetime.utcfromtimestamp(0)).total_seconds() * 1000)
 
         if 'module_name' not in params:
@@ -985,7 +988,7 @@ class CatalogController:
             raise ValueError(
                 'Add favorite operation failed - some unknown database error: ' + error)
 
-    def remove_favorite(self, params, username):
+    def remove_favorite(self, params, username, token):
         if 'module_name' not in params:
             module_name = 'nms.legacy'
         elif not params['module_name']:
@@ -1007,7 +1010,7 @@ class CatalogController:
             raise ValueError(
                 'Remove favorite operation failed - some unknown database error: ' + error)
 
-    def list_user_favorites(self, username):
+    def list_user_favorites(self, username, token):
         return self.db.list_user_favorites(username)
 
     def list_app_favorites(self, item):
@@ -1165,15 +1168,17 @@ class CatalogController:
         return params
 
     # always true if the user is in the admin list
-    def has_permission(self, username, owners):
-        if self.is_admin(username):
+    def has_permission(self, username, token, owners):
+        if self.is_admin(username, token):
             return True
         for owner in owners:
             if username == owner['kb_username']:
                 return True
         return False
 
-    def is_admin(self, username):
+    def is_admin(self, username, token):
+        #r = requests.get(self.auth_url + 'api/V2/me', headers={'Authorization': token})
+
         if username in self.adminList:
             return True
         return False
@@ -1181,10 +1186,10 @@ class CatalogController:
     def version(self):
         return biokbase.catalog.version.CATALOG_VERSION
 
-    def log_exec_stats(self, admin_user_id, user_id, app_module_name, app_id, func_module_name,
+    def log_exec_stats(self, username, token, user_id, app_module_name, app_id, func_module_name,
                        func_name, git_commit_hash, creation_time, exec_start_time, finish_time,
                        is_error, job_id):
-        if not self.is_admin(admin_user_id):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to log execution statistics.')
         self.db.add_exec_stats_raw(user_id, app_module_name, app_id, func_module_name, func_name,
                                    git_commit_hash, creation_time, exec_start_time, finish_time,
@@ -1205,8 +1210,8 @@ class CatalogController:
         time_range = None if per_week else "*"
         return self.db.get_exec_stats_apps(full_app_ids, type, time_range)
 
-    def get_exec_aggr_table(self, requesting_user, params):
-        if not self.is_admin(requesting_user):
+    def get_exec_aggr_table(self, username, token, params):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to view this data.')
 
         minTime = None
@@ -1218,8 +1223,8 @@ class CatalogController:
 
         return self.db.aggr_exec_stats_table(minTime, maxTime)
 
-    def get_exec_raw_stats(self, requesting_user, params):
-        if not self.is_admin(requesting_user):
+    def get_exec_raw_stats(self, username, token, params):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to view this data.')
 
         minTime = None
@@ -1231,9 +1236,9 @@ class CatalogController:
 
         return self.db.get_exec_raw_stats(minTime, maxTime)
 
-    def set_client_group_config(self, username, config):
+    def set_client_group_config(self, username, token, config):
 
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to set execution client groups.')
 
         record = {}
@@ -1265,9 +1270,9 @@ class CatalogController:
             raise ValueError(
                 'Update probably failed, blame mongo: update operation returned: ' + error)
 
-    def remove_client_group_config(self, username, config):
+    def remove_client_group_config(self, username, token, config):
         # do some parameter checks
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to remove volume mounts.')
 
         selection = {}
@@ -1324,9 +1329,9 @@ class CatalogController:
 
         return groups
 
-    def set_volume_mount(self, username, config):
+    def set_volume_mount(self, username, token, config):
         # must be an admin
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to set volume mounts.')
 
         # do lots of parameter checking
@@ -1395,9 +1400,9 @@ class CatalogController:
             raise ValueError(
                 'Insert/update probably failed, blame mongo: upsert operation returned: ' + error)
 
-    def remove_volume_mount(self, username, config):
+    def remove_volume_mount(self, username, token, config):
         # do some parameter checks
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to remove volume mounts.')
 
         selection = {}
@@ -1425,9 +1430,9 @@ class CatalogController:
             raise ValueError(
                 'Removal probably failed, blame mongo: remove operation returned: ' + error)
 
-    def list_volume_mounts(self, username, filter):
+    def list_volume_mounts(self, username, token, filter):
         # add some checks on the filter
-        if not self.is_admin(username):
+        if not self.is_admin(username, token):
             raise ValueError('You do not have permission to view volume mounts.')
 
         processed_filter = {}
@@ -1452,8 +1457,8 @@ class CatalogController:
 
         return self.db.list_volume_mounts(processed_filter)
 
-    def set_secure_config_params(self, username, params):
-        if username is None or not self.is_admin(username):
+    def set_secure_config_params(self, username, token, params):
+        if username is None or not self.is_admin(username, token):
             raise ValueError('You do not have permission to work with hidden configuration ' +
                              'parameters.')
 
@@ -1464,8 +1469,8 @@ class CatalogController:
         data_list = params['data']
         self.db.set_secure_config_params(data_list)
 
-    def remove_secure_config_params(self, username, params):
-        if username is None or not self.is_admin(username):
+    def remove_secure_config_params(self, username, token, params):
+        if username is None or not self.is_admin(username, token):
             raise ValueError('You do not have permission to work with hidden configuration ' +
                              'parameters.')
 
@@ -1476,8 +1481,8 @@ class CatalogController:
         data_list = params['data']
         self.db.remove_secure_config_params(data_list)
 
-    def get_secure_config_params(self, username, params):
-        if username is None or not self.is_admin(username):
+    def get_secure_config_params(self, username, token, params):
+        if username is None or not self.is_admin(username, token):
             raise ValueError('You do not have permission to work with hidden configuration ' +
                              'parameters.')
 

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -919,16 +919,14 @@ public class CatalogClient {
      * <pre>
      * returns true (1) if the user is an admin, false (0) otherwise
      * </pre>
-     * @param   username   instance of String
      * @return   instance of original type "boolean" (@range [0,1])
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public Long isAdmin(String username, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public Long isAdmin(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
-        args.add(username);
         TypeReference<List<Long>> retType = new TypeReference<List<Long>>() {};
-        List<Long> res = caller.jsonrpcCall("Catalog.is_admin", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        List<Long> res = caller.jsonrpcCall("Catalog.is_admin", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -598,17 +598,15 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms, service_v
             [filter], 1, _callback, _errorCallback);
     };
  
-     this.is_admin = function (username, _callback, _errorCallback) {
-        if (typeof username === 'function')
-            throw 'Argument username can not be a function';
+     this.is_admin = function (_callback, _errorCallback) {
         if (_callback && typeof _callback !== 'function')
             throw 'Argument _callback must be a function if defined';
         if (_errorCallback && typeof _errorCallback !== 'function')
             throw 'Argument _errorCallback must be a function if defined';
-        if (typeof arguments === 'function' && arguments.length > 1+2)
-            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        if (typeof arguments === 'function' && arguments.length > 0+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(0+2)+')';
         return json_call_ajax(_url, "Catalog.is_admin",
-            [username], 1, _callback, _errorCallback);
+            [], 1, _callback, _errorCallback);
     };
  
      this.set_secure_config_params = function (params, _callback, _errorCallback) {

--- a/test/admin_methods_test.py
+++ b/test/admin_methods_test.py
@@ -12,10 +12,9 @@ class AdminMethodsTest(unittest.TestCase):
         userName = self.cUtil.user_ctx()['user_id']
         adminName = self.cUtil.admin_ctx()['user_id']
 
-        with self.assertRaises(ValueError):
-            self.assertEqual(self.catalog.is_admin(self.cUtil.anonymous_ctx(), madeUpName)[0], 0)
-        self.assertEqual(self.catalog.is_admin(self.cUtil.user_ctx(), userName)[0], 0)
-        self.assertEqual(self.catalog.is_admin(self.cUtil.admin_ctx(), adminName)[0], 1)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.anonymous_ctx())[0], 0)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.user_ctx())[0], 0)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.admin_ctx())[0], 1)
 
     # assumes no developers have been added yet
     def test_add_remove_developers(self):

--- a/test/admin_methods_test.py
+++ b/test/admin_methods_test.py
@@ -12,11 +12,10 @@ class AdminMethodsTest(unittest.TestCase):
         userName = self.cUtil.user_ctx()['user_id']
         adminName = self.cUtil.admin_ctx()['user_id']
 
-        ctx = self.cUtil.anonymous_ctx()
-
-        self.assertEqual(self.catalog.is_admin(ctx, madeUpName)[0], 0)
-        self.assertEqual(self.catalog.is_admin(ctx, userName)[0], 0)
-        self.assertEqual(self.catalog.is_admin(ctx, adminName)[0], 1)
+        with self.assertRaises(ValueError):
+            self.assertEqual(self.catalog.is_admin(self.cUtil.anonymous_ctx(), madeUpName)[0], 0)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.user_ctx(), userName)[0], 0)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.admin_ctx(), adminName)[0], 1)
 
     # assumes no developers have been added yet
     def test_add_remove_developers(self):

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -75,7 +75,9 @@ class CatalogTestUtil:
             'nms-admin-token': self.test_cfg.get('nms-admin-token', ''),
             'ref-data-base': self.test_cfg['ref-data-base'],
             'kbase-endpoint': self.test_cfg['kbase-endpoint'],
-            'auth-service-url': self.test_cfg.get('auth-service-url', '')
+            'admin-roles': self.test_cfg['admin-roles'],
+            # this points to the mocked Auth API running in a docker container
+            'auth-service-url': 'http://localhost:7777'
         }
         self.dockerclient = DockerAPIClient(base_url=self.catalog_cfg['docker-base-url'])
 
@@ -199,7 +201,7 @@ class CatalogTestUtil:
     def user_ctx(self):
         return {
             "user_id": self.test_user_1,
-            "token": 'user_token'
+            "token": 'non_admin_token'
         }
 
     def admin_ctx(self):

--- a/test/catalog_test_util.py
+++ b/test/catalog_test_util.py
@@ -199,15 +199,13 @@ class CatalogTestUtil:
     def user_ctx(self):
         return {
             "user_id": self.test_user_1,
-            "token": 'fake_token'
-            # TODO: authenticate and add real token, but not required yet
+            "token": 'user_token'
         }
 
     def admin_ctx(self):
         return {
             "user_id": self.test_user_2,
-            "token": 'fake_token'
-            # TODO: authenticate and add real token, but not required yet
+            "token": 'admin_token'
         }
 
     def get_test_repo_1(self):

--- a/test/favorites_test.py
+++ b/test/favorites_test.py
@@ -37,7 +37,7 @@ class BasicCatalogTest(unittest.TestCase):
         time.sleep(1)  # force different timestamps so sort works
         self.catalog.add_favorite(ctx,
                                   {'module_name': 'MegaHit', 'id': 'run_megahit_2'})
-        favs2 = self.catalog.list_favorites({}, user)[0]
+        favs2 = self.catalog.list_favorites(ctx, user)[0]
         favs2.sort(key=lambda x: x['timestamp'], reverse=True)
         self.assertEqual(len(favs2), 2)
         self.assertEqual(favs2[0]['module_name_lc'], 'megahit')

--- a/test/mock_auth/endpoints.json
+++ b/test/mock_auth/endpoints.json
@@ -1,0 +1,95 @@
+[
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "headers": {
+      "Authorization": "non_admin_token"
+    },
+    "response": {
+      "status": "200",
+      "body": {
+        "created": 1528306100471,
+        "lastlogin": 1542068355002,
+        "display": "Test User",
+        "roles": [],
+        "customroles": [],
+        "policyids": [],
+        "user": "username",
+        "local": false,
+        "email": "user@example.com",
+        "idents": []
+      }
+    }
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "headers": {
+      "Authorization": "admin_token"
+    },
+    "response": {
+      "status": "200",
+      "body": {
+        "created": 1528306100471,
+        "lastlogin": 1542068355002,
+        "display": "Test User",
+        "roles": [],
+        "customroles": [
+          "CATALOG_ADMIN"
+        ],
+        "policyids": [],
+        "user": "username",
+        "local": false,
+        "email": "user@example.com",
+        "idents": []
+      }
+    }
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "headers": {
+      "Authorization": "invalid_token"
+    },
+    "response": {
+      "status": "401",
+      "body": {
+        "error": {
+          "httpcode": 401,
+          "httpstatus": "Unauthorized",
+          "appcode": 10020,
+          "apperror": "Invalid token",
+          "message": "10020 Invalid token",
+          "callid": "1757210147564211",
+          "time": 1542737889450
+        }
+      }
+    }
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "path": "/api/V2/me",
+    "response": {
+      "status": "400",
+      "body": {
+        "error": {
+          "httpcode": 400,
+          "httpstatus": "Bad Request",
+          "appcode": 10010,
+          "apperror": "No authentication token",
+          "message": "10010 No authentication token: No user token provided",
+          "callid": "7334881776774415",
+          "time": 1542737656377
+        }
+      }
+    }
+  }
+]

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -15,8 +15,11 @@ classpath=`cat ../narrative_method_store/dist/jar.classpath.txt`
 java -cp $classpath us.kbase.narrativemethodstore.NarrativeMethodStoreServer 7125 > nms/error.log 2>&1 &
 NMS_PID=$!
 
+echo 'Starting Mock Auth API...'
+docker run -d --rm -v ${PWD}/mock_auth:/config -p 7777:5000 --name mock-auth mockservices/mock_json_service
+
 echo 'Waiting for NMS to start...'
-sleep 30
+sleep 25
 curl -d '{"id":"1","params":[],"method":"NarrativeMethodStore.ver","version":"1.1"}' http://localhost:7125
 if [ $? -ne 0 ]; then
     kill -9 $NMS_PID
@@ -25,7 +28,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo '\nStarting local Docker Registry...'
-docker run -d -p 5000:5000 --name registry registry:2
+docker run -d --rm -p 5000:5000 --name registry registry:2
 if [ $? -ne 0 ]; then
     docker start registry
     if [ $? -ne 0 ]; then
@@ -56,9 +59,8 @@ echo "unit tests returned with error code=${TEST_RETURN_CODE}"
 # stop NMS
 kill -9 $NMS_PID
 
-# stop Docker Registry
+#stop Docker containers
+docker stop mock-auth
 docker stop registry
-docker rm registry
-
 
 exit ${TEST_RETURN_CODE}

--- a/test/test.cfg.example
+++ b/test/test.cfg.example
@@ -13,6 +13,7 @@
 
 # The KBase auth server url.
 auth-server-url = https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login
+admin-roles = KBASE_ADMIN,CATALOG_ADMIN
 
 # user accounts for testing (should be different accounts)
 test-user-1 = wstester1


### PR DESCRIPTION
Use KBASE_ADMIN, CATALOG_ADMIN custom roles in auth2 to set admin status rather than a list loaded at the start. 
- Auth service is mocked for testing 
- is_admin now only returns admin status for the user calling based on token