### PR TITLE
Avoid changing the signature of is_auth

### DIFF
--- a/catalog.spec
+++ b/catalog.spec
@@ -781,8 +781,11 @@ module Catalog {
     funcdef list_volume_mounts(VolumeMountFilter filter)
                 returns (list<VolumeMountConfig> volume_mount_configs) authentication required;
 
-    /* returns true (1) if the user is an admin, false (0) otherwise */
-    funcdef is_admin() returns (boolean) authentication required;
+    /* returns true (1) if the user is an admin, false (0) otherwise.
+       NOTE: username is now ignored (it checks the token) but retained for back compatibility
+    */
+
+    funcdef is_admin(string username) returns (boolean); 
 
     /*
         version - optional version (commit hash, tag or semantic one) of module, if not set

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -4658,7 +4658,7 @@ boolean is an int
 
 =head2 is_admin
 
-  $return = $obj->is_admin()
+  $return = $obj->is_admin($username)
 
 =over 4
 
@@ -4667,6 +4667,7 @@ boolean is an int
 =begin html
 
 <pre>
+$username is a string
 $return is a Catalog.boolean
 boolean is an int
 
@@ -4676,6 +4677,7 @@ boolean is an int
 
 =begin text
 
+$username is a string
 $return is a Catalog.boolean
 boolean is an int
 
@@ -4694,12 +4696,23 @@ returns true (1) if the user is an admin, false (0) otherwise
 {
     my($self, @args) = @_;
 
-# Authentication: required
+# Authentication: none
 
-    if ((my $n = @args) != 0)
+    if ((my $n = @args) != 1)
     {
 	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
-							       "Invalid argument count for function is_admin (received $n, expecting 0)");
+							       "Invalid argument count for function is_admin (received $n, expecting 1)");
+    }
+    {
+	my($username) = @args;
+
+	my @_bad_arguments;
+        (!ref($username)) or push(@_bad_arguments, "Invalid type for argument 1 \"username\" (value was \"$username\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to is_admin:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'is_admin');
+	}
     }
 
     my $url = $self->{url};

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -954,13 +954,14 @@ class Catalog(object):
         return self._client.call_method('Catalog.list_volume_mounts',
                                         [filter], self._service_ver, context)
 
-    def is_admin(self, context=None):
+    def is_admin(self, username, context=None):
         """
         returns true (1) if the user is an admin, false (0) otherwise
+        :param username: instance of String
         :returns: instance of type "boolean" (@range [0,1])
         """
         return self._client.call_method('Catalog.is_admin',
-                                        [], self._service_ver, context)
+                                        [username], self._service_ver, context)
 
     def set_secure_config_params(self, params, context=None):
         """

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -21,7 +21,7 @@ class Catalog:
     ######################################### noqa
     VERSION = "0.0.1"
     GIT_URL = "https://github.com/kbase/catalog.git"
-    GIT_COMMIT_HASH = "45437dca268d2b42cabf1850666fa9da125cf3a2"
+    GIT_COMMIT_HASH = "c8ec57c862629b9ac606c3ed405981aef1b7e22d"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -1336,14 +1336,17 @@ class Catalog:
         # return the results
         return [volume_mount_configs]
 
-    def is_admin(self, ctx):
+    def is_admin(self, ctx, username):
         """
         returns true (1) if the user is an admin, false (0) otherwise
+        :param username: instance of String
         :returns: instance of type "boolean" (@range [0,1])
         """
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN is_admin
+        if username and ctx.get('user_id') and username != ctx['user_id']:
+            raise ValueError("Can only check on own admin status")
         if self.cc.is_admin(ctx.get('user_id'), ctx.get('token')):
             returnVal = 1
         else:

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -520,8 +520,8 @@ class Application(object):
         self.method_authentication['Catalog.list_volume_mounts'] = 'required'  # noqa
         self.rpc_service.add(impl_Catalog.is_admin,
                              name='Catalog.is_admin',
-                             types=[])
-        self.method_authentication['Catalog.is_admin'] = 'required'  # noqa
+                             types=[str])
+        self.method_authentication['Catalog.is_admin'] = 'none'  # noqa
         self.rpc_service.add(impl_Catalog.set_secure_config_params,
                              name='Catalog.set_secure_config_params',
                              types=[dict])

--- a/lib/biokbase/catalog/version.py
+++ b/lib/biokbase/catalog/version.py
@@ -1,2 +1,2 @@
 # File that simply defines version information
-CATALOG_VERSION = '2.2.0'
+CATALOG_VERSION = '2.2.1'

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -919,14 +919,16 @@ public class CatalogClient {
      * <pre>
      * returns true (1) if the user is an admin, false (0) otherwise
      * </pre>
+     * @param   username   instance of String
      * @return   instance of original type "boolean" (@range [0,1])
      * @throws IOException if an IO exception occurs
      * @throws JsonClientException if a JSON RPC exception occurs
      */
-    public Long isAdmin(RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+    public Long isAdmin(String username, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
         List<Object> args = new ArrayList<Object>();
+        args.add(username);
         TypeReference<List<Long>> retType = new TypeReference<List<Long>>() {};
-        List<Long> res = caller.jsonrpcCall("Catalog.is_admin", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        List<Long> res = caller.jsonrpcCall("Catalog.is_admin", args, retType, true, false, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -598,15 +598,17 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms, service_v
             [filter], 1, _callback, _errorCallback);
     };
  
-     this.is_admin = function (_callback, _errorCallback) {
+     this.is_admin = function (username, _callback, _errorCallback) {
+        if (typeof username === 'function')
+            throw 'Argument username can not be a function';
         if (_callback && typeof _callback !== 'function')
             throw 'Argument _callback must be a function if defined';
         if (_errorCallback && typeof _errorCallback !== 'function')
             throw 'Argument _errorCallback must be a function if defined';
-        if (typeof arguments === 'function' && arguments.length > 0+2)
-            throw 'Too many arguments ('+arguments.length+' instead of '+(0+2)+')';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
         return json_call_ajax(_url, "Catalog.is_admin",
-            [], 1, _callback, _errorCallback);
+            [username], 1, _callback, _errorCallback);
     };
  
      this.set_secure_config_params = function (params, _callback, _errorCallback) {

--- a/test/admin_methods_test.py
+++ b/test/admin_methods_test.py
@@ -12,9 +12,11 @@ class AdminMethodsTest(unittest.TestCase):
         userName = self.cUtil.user_ctx()['user_id']
         adminName = self.cUtil.admin_ctx()['user_id']
 
-        self.assertEqual(self.catalog.is_admin(self.cUtil.anonymous_ctx())[0], 0)
-        self.assertEqual(self.catalog.is_admin(self.cUtil.user_ctx())[0], 0)
-        self.assertEqual(self.catalog.is_admin(self.cUtil.admin_ctx())[0], 1)
+        with self.assertRaisesRegex(ValueError, 'Can only check on own admin status'):
+            self.assertEqual(self.catalog.is_admin(self.cUtil.user_ctx(), adminName)[0], 0)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.anonymous_ctx(), madeUpName)[0], 0)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.user_ctx(), userName)[0], 0)
+        self.assertEqual(self.catalog.is_admin(self.cUtil.admin_ctx(), adminName)[0], 1)
 
     # assumes no developers have been added yet
     def test_add_remove_developers(self):


### PR DESCRIPTION
So it's a little janky to have an ignored parameter but I'm thinking that retaining the old function signature is the best way to go because it avoids tight coupling of the catalog front-end and the back-end