### PR TITLE
Create deploy.minikb.cfg.templ

### DIFF
--- a/deployment/conf/.templates/deploy.minikb.cfg.templ
+++ b/deployment/conf/.templates/deploy.minikb.cfg.templ
@@ -1,0 +1,50 @@
+[catalog]
+
+# host where mongo lives, e.g. localhost:27017
+mongodb-host = {{ default .Env.mongodb_host "localhost:27017" }}
+
+# name of the workspace mongo database
+mongodb-database = {{ default .Env.mongodb_database "catalog" }}
+
+# the user name for an account with readWrite access to the database
+mongodb-user = {{ default .Env.mongodb_user "" }}
+
+# password for the account
+mongodb-pwd = {{ default .Env.mongodb_pwd "" }}
+
+# The KBase auth server url.
+auth-service-url = {{ default .Env.auth_service_url "https://kbase.us/services/authorization/Sessions/Login" }}
+# The KBase auth API.
+auth-service-api = {{ default .Env.auth_service_url2 "https://ci.kbase.us/services" }}
+
+# Path to docker socket/host
+docker-base-url = {{ default .Env.docker_base_url "unix://var/run/docker.sock" }}
+# for tcp: "tcp://host:port"
+# Docker registry to use
+docker-registry-host = {{ default .Env.docker_registry_host "dockerhub-ci.kbase.us" }}
+
+# Roles that can review/approve/disable modules and releases.
+# Multiple admin roles can be specified as a comma delimited list
+admin-roles = {{ default .Env.admin_roles "KBASE_ADMIN,CATALOG_ADMIN" }}
+
+# Temporary working directory for checking out repos and doing stuff
+temp-dir = {{ default .Env.temp_dir "" }} 
+
+# Configuration for server (uwsgi) variables
+service-port = {{ default .Env.service_port "5000" }}
+http-timeout = {{ default .Env.http_timeout "600" }}
+processes = {{ default .Env.processes "20" }}
+threads = {{ default .Env.threads "4" }}
+cheaper = {{ default .Env.cheaper "4" }}
+
+# Narrative Method Store configuration. Provide either a token or a uid/pwd.
+# If both are provided, the token is used.
+nms-url = {{ default .Env.nms_url "https://ci.kbase.us/services/narrative_method_store/rpc" }}
+nms-admin-token ={{ default .Env.nms_admin_token "" }}
+
+# File system path to mounted network drive used for reference data
+ref-data-base = {{ default .Env.ref_data_base "/kb/data" }}
+
+# KBase services end-point used for configuration generation in ref-data initialization
+kbase-endpoint = {{ default .Env.kbase_endpoint "https://ci.kbase.us/services" }}
+


### PR DESCRIPTION
This is required to be able to configure both endpoints to point to test-mode in mini_kb.