### PR TITLE
add authMechanism to authenticate()

### DIFF
--- a/deployment/conf/.templates/deploy.cfg.templ
+++ b/deployment/conf/.templates/deploy.cfg.templ
@@ -12,6 +12,9 @@ mongodb-user = {{ default .Env.mongodb_user "" }}
 # password for the account
 mongodb-pwd = {{ default .Env.mongodb_pwd "" }}
 
+# auth mechanism
+mongodb-authmechanism = {{ default .Env.mongodb_authMechanism "DEFAULT" }}
+
 # The KBase auth server url.
 auth-service-url = {{ default .Env.auth_service_url "https://kbase.us/services/authorization/Sessions/Login" }}
 # The KBase auth API.

--- a/lib/biokbase/catalog/controller.py
+++ b/lib/biokbase/catalog/controller.py
@@ -52,13 +52,17 @@ class CatalogController:
         if 'mongodb-pwd' not in config:  # pragma: no cover
             warnings.warn('"mongodb-pwd" is not set in config of CatalogController.')
             config['mongodb-pwd'] = ''
+        if 'mongodb-authmechanism' not in config:  # pragma: no cover
+            warnings.warn('"mongodb-authmechanism" is not set in config of CatalogController, using DEFAULT.')
+            config['mongodb-authmechanism'] = 'DEFAULT'
 
         # instantiate the mongo client
         self.db = MongoCatalogDBI(
             config['mongodb-host'],
             config['mongodb-database'],
             config['mongodb-user'],
-            config['mongodb-pwd'])
+            config['mongodb-pwd'],
+            config['mongodb-authmechanism'])
 
         # check for the temp directory and make sure it exists
         if 'temp-dir' not in config:  # pragma: no cover

--- a/lib/biokbase/catalog/db.py
+++ b/lib/biokbase/catalog/db.py
@@ -118,14 +118,17 @@ class MongoCatalogDBI:
     _EXEC_STATS_USERS = 'exec_stats_users'
     _SECURE_CONFIG_PARAMS = 'secure_config_params'
 
-    def __init__(self, mongo_host, mongo_db, mongo_user, mongo_psswd):
+    def __init__(self, mongo_host, mongo_db, mongo_user, mongo_psswd, mongo_authMechanism):
 
         # create the client
         self.mongo = MongoClient('mongodb://' + mongo_host)
 
         # Try to authenticate, will throw an exception if the user/psswd is not valid for the db
+        # the pymongo docs say authenticate() is deprecated, but testing putting auth in
+        # the MongoClient call failed
+        # to do: add authMechanism as an argument
         if (mongo_user and mongo_psswd):
-            self.mongo[mongo_db].authenticate(mongo_user, mongo_psswd)
+            self.mongo[mongo_db].authenticate(mongo_user, mongo_psswd, mechanism=mongo_authMechanism)
 
         # Grab a handle to the database and collections
         self.db = self.mongo[mongo_db]

--- a/lib/biokbase/catalog/version.py
+++ b/lib/biokbase/catalog/version.py
@@ -1,2 +1,2 @@
 # File that simply defines version information
-CATALOG_VERSION = '2.2.2'
+CATALOG_VERSION = '2.2.3'

--- a/service/start_service.template
+++ b/service/start_service.template
@@ -22,13 +22,6 @@ threads="$(python $KB_SERVICE_DIR/get_kb_config.py $KB_SERVICE_NAME threads)"
 cheaper="$(python $KB_SERVICE_DIR/get_kb_config.py $KB_SERVICE_NAME cheaper)"
 http_timeout="$(python $KB_SERVICE_DIR/get_kb_config.py $KB_SERVICE_NAME http-timeout)"
 
-
-if [ -f $pid_file ] ; then 
-    echo "pid file already exists: $pid_file"
-    echo "Is $KB_SERVICE_NAME already running?  Either stop the service or delete the pid file."
-    exit 1
-fi
-
 uwsgi --master \
     --processes $processes \
     --threads $threads \


### PR DESCRIPTION
pymongo by default does not use MONGODB-CR with mongod 3.x servers, which causes problems with instances which have been upgraded from 2.6 to 3.0 but have not updated to SCRAM yet.  Add a config option to specify an authMechanism if needed.