### PR TITLE
Add app estimator lookup function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DIR = $(shell pwd)
 
 LIB_DIR = lib
 
-PATH := kb_sdk/bin:$(PATH)
+# PATH := kb_sdk/bin:$(PATH)
 
 default: init
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DIR = $(shell pwd)
 
 LIB_DIR = lib
 
-# PATH := kb_sdk/bin:$(PATH)
+PATH := kb_sdk/bin:$(PATH)
 
 default: init
 

--- a/catalog.spec
+++ b/catalog.spec
@@ -10,6 +10,35 @@ module Catalog {
     funcdef version() returns (string version);
 
     /*
+        module_name - module with the app of interest
+        app_id - app we're interested in the estimator for
+        tag - release, beta, dev
+    */
+    typedef structure {
+        string module_name;
+        string app_id;
+        string tag;
+    } GetAppResourceEstimatorParams;
+
+    /*
+        estimator_module - module containing the estimator method
+        estimator_method - the estimator method to run
+        tag - release, beta, dev
+    */
+    typedef structure {
+        string estimator_module;
+        string estimator_method;
+        string tag;
+    } GetAppResourceEstimatorResults;
+
+    /*
+        Look up the resource estimator for an app. Always returns the same structure, but the module
+        and method are nulls if no estimator is assigned to that app.
+    */
+    funcdef get_app_resource_estimator(GetAppResourceEstimatorParams params) returns (GetAppResourceEstimatorResults);
+
+
+    /*
         Describes how to find a single module/repository.
         module_name - name of module defined in kbase.yaml file;
         git_url - the url used to register the module
@@ -27,7 +56,7 @@ module Catalog {
         string git_commit_hash;
     } RegisterRepoParams;
 
-    /* allow/require developer to supply git branch/git commit tag? 
+    /* allow/require developer to supply git branch/git commit tag?
     if this is a new module, creates the initial registration with the authenticated user as
     the sole owner, then launches a build to update the dev version of the module.  You can check
     the state of this build with the 'get_module_state' method passing in the git_url.  If the module
@@ -58,7 +87,7 @@ module Catalog {
 
     /*
         decision - approved | denied
-        review_message - 
+        review_message -
     */
     typedef structure {
         string module_name;
@@ -138,7 +167,7 @@ module Catalog {
 
     /* if favorite item is given, will return stars just for that item.  If a module
     name is given, will return stars for all methods in that module.  If none of
-    those are given, then will return stars for every method that there is info on 
+    those are given, then will return stars for every method that there is info on
 
     parameters to add:
         list<FavoriteItem> items;
@@ -193,12 +222,12 @@ module Catalog {
     /*
         data_folder - optional field representing unique module name (like <module_name> transformed to
             lower cases) used for reference data purposes (see description for data_version field). This
-            value will be treated as part of file system path relative to the base that comes from the 
+            value will be treated as part of file system path relative to the base that comes from the
             config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-        data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+        data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
             key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
             should be initialized by running docker image with "init" target from catalog. And later when
-            async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+            async methods are run it should be mounted on AWE worker machine into "/data" folder inside
             docker container by execution engine.
     */
     typedef structure {
@@ -291,7 +320,7 @@ module Catalog {
         local_function_ids     - list of Local Function ids registered with this module version
 
         docker_img_name        - name of the docker image for this module created on registration
-        data_folder            - name of the data folder used 
+        data_folder            - name of the data folder used
 
         compilation_report     - (optionally returned) summary of the KIDL specification compilation
     */
@@ -581,7 +610,7 @@ module Catalog {
 
     funcdef list_builds(ListBuildParams params) returns (list<BuildInfo> builds);
 
-    
+
 
     /* all fields are required to make sure you update the right one */
     typedef structure {
@@ -647,7 +676,7 @@ module Catalog {
     /*
         full_app_ids - list of fully qualified app IDs (including module_name prefix followed by
             slash in case of dynamically registered repo).
-        per_week - optional flag switching results to weekly data rather than one row per app for 
+        per_week - optional flag switching results to weekly data rather than one row per app for
             all time (default value is false)
     */
     typedef structure {
@@ -663,7 +692,7 @@ module Catalog {
             or ISO-encoded week like "2016-W01")
         total_queue_time - summarized time difference between exec_start_time and creation_time moments
             defined in seconds since Epoch (POSIX),
-        total_exec_time - summarized time difference between finish_time and exec_start_time moments 
+        total_exec_time - summarized time difference between finish_time and exec_start_time moments
             defined in seconds since Epoch (POSIX).
     */
     typedef structure {
@@ -707,7 +736,7 @@ module Catalog {
     */
 
 
-    /* app_id = full app id; if module name is used it will be case insensitive 
+    /* app_id = full app id; if module name is used it will be case insensitive
         this will overwrite all existing client groups (it won't just push what's on the list)
         If client_groups is empty or set to null, then the client_group mapping will be removed.
     */
@@ -777,7 +806,7 @@ module Catalog {
         string function_name;
         string client_group;
     } VolumeMountFilter;
-    
+
     funcdef list_volume_mounts(VolumeMountFilter filter)
                 returns (list<VolumeMountConfig> volume_mount_configs) authentication required;
 
@@ -799,7 +828,7 @@ module Catalog {
         boolean is_password;
         string param_value;
     } SecureConfigParameter;
-    
+
     typedef structure {
         list<SecureConfigParameter> data;
     } ModifySecureConfigParamsInput;
@@ -807,21 +836,21 @@ module Catalog {
     /*
         Only admins can use this function.
     */
-    funcdef set_secure_config_params(ModifySecureConfigParamsInput params) 
+    funcdef set_secure_config_params(ModifySecureConfigParamsInput params)
         returns () authentication required;
 
     /*
         Only admins can use this function.
     */
-    funcdef remove_secure_config_params(ModifySecureConfigParamsInput params) 
+    funcdef remove_secure_config_params(ModifySecureConfigParamsInput params)
         returns () authentication required;
 
     /*
         version - optional version (commit hash, tag or semantic one) of module, if
             not set then default "release" value is used;
-        load_all_versions - optional flag indicating that all parameter versions 
+        load_all_versions - optional flag indicating that all parameter versions
             should be loaded (version filter is not applied), default value is 0.
-    */    
+    */
     typedef structure {
         string module_name;
         string version;
@@ -831,7 +860,7 @@ module Catalog {
     /*
         Only admins can use this function.
     */
-    funcdef get_secure_config_params(GetSecureConfigParamsInput params) 
+    funcdef get_secure_config_params(GetSecureConfigParamsInput params)
         returns (list<SecureConfigParameter>) authentication required;
 
 };

--- a/lib/Bio/KBase/Catalog/Client.pm
+++ b/lib/Bio/KBase/Catalog/Client.pm
@@ -177,6 +177,105 @@ Get the version of the deployed catalog service endpoint.
  
 
 
+=head2 get_app_resource_estimator
+
+  $return = $obj->get_app_resource_estimator($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a Catalog.GetAppResourceEstimatorParams
+$return is a Catalog.GetAppResourceEstimatorResults
+GetAppResourceEstimatorParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	app_id has a value which is a string
+	tag has a value which is a string
+GetAppResourceEstimatorResults is a reference to a hash where the following keys are defined:
+	estimator_module has a value which is a string
+	estimator_method has a value which is a string
+	tag has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a Catalog.GetAppResourceEstimatorParams
+$return is a Catalog.GetAppResourceEstimatorResults
+GetAppResourceEstimatorParams is a reference to a hash where the following keys are defined:
+	module_name has a value which is a string
+	app_id has a value which is a string
+	tag has a value which is a string
+GetAppResourceEstimatorResults is a reference to a hash where the following keys are defined:
+	estimator_module has a value which is a string
+	estimator_method has a value which is a string
+	tag has a value which is a string
+
+
+=end text
+
+=item Description
+
+Look up the resource estimator for an app. Always returns the same structure, but the module
+and method are nulls if no estimator is assigned to that app.
+
+=back
+
+=cut
+
+ sub get_app_resource_estimator
+{
+    my($self, @args) = @_;
+
+# Authentication: none
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function get_app_resource_estimator (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to get_app_resource_estimator:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'get_app_resource_estimator');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "Catalog.get_app_resource_estimator",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'get_app_resource_estimator',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_app_resource_estimator",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'get_app_resource_estimator',
+				       );
+    }
+}
+ 
+
+
 =head2 is_registered
 
   $return = $obj->is_registered($params)
@@ -301,7 +400,7 @@ RegisterRepoParams is a reference to a hash where the following keys are defined
 
 =item Description
 
-allow/require developer to supply git branch/git commit tag? 
+allow/require developer to supply git branch/git commit tag?
 if this is a new module, creates the initial registration with the authenticated user as
 the sole owner, then launches a build to update the dev version of the module.  You can check
 the state of this build with the 'get_module_state' method passing in the git_url.  If the module
@@ -5159,6 +5258,88 @@ an int
 
 
 
+=head2 GetAppResourceEstimatorParams
+
+=over 4
+
+
+
+=item Description
+
+module_name - module with the app of interest
+app_id - app we're interested in the estimator for
+tag - release, beta, dev
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+app_id has a value which is a string
+tag has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+module_name has a value which is a string
+app_id has a value which is a string
+tag has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 GetAppResourceEstimatorResults
+
+=over 4
+
+
+
+=item Description
+
+estimator_module - module containing the estimator method
+estimator_method - the estimator method to run
+tag - release, beta, dev
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+estimator_module has a value which is a string
+estimator_method has a value which is a string
+tag has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+estimator_module has a value which is a string
+estimator_method has a value which is a string
+tag has a value which is a string
+
+
+=end text
+
+=back
+
+
+
 =head2 SelectOneModuleParams
 
 =over 4
@@ -5523,7 +5704,7 @@ timestamp has a value which is a string
 
 if favorite item is given, will return stars just for that item.  If a module
 name is given, will return stars for all methods in that module.  If none of
-those are given, then will return stars for every method that there is info on 
+those are given, then will return stars for every method that there is info on
 
 parameters to add:
     list<FavoriteItem> items;
@@ -5775,12 +5956,12 @@ spec_files has a value which is a reference to a list where each element is a Ca
 
 data_folder - optional field representing unique module name (like <module_name> transformed to
     lower cases) used for reference data purposes (see description for data_version field). This
-    value will be treated as part of file system path relative to the base that comes from the 
+    value will be treated as part of file system path relative to the base that comes from the
     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
     should be initialized by running docker image with "init" target from catalog. And later when
-    async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+    async methods are run it should be mounted on AWE worker machine into "/data" folder inside
     docker container by execution engine.
 
 
@@ -5962,7 +6143,7 @@ narrative_app_ids      - list of Narrative App ids registered with this module v
 local_function_ids     - list of Local Function ids registered with this module version
 
 docker_img_name        - name of the docker image for this module created on registration
-data_folder            - name of the data folder used 
+data_folder            - name of the data folder used
 
 compilation_report     - (optionally returned) summary of the KIDL specification compilation
 
@@ -6895,7 +7076,7 @@ job_id has a value which is a string
 
 full_app_ids - list of fully qualified app IDs (including module_name prefix followed by
     slash in case of dynamically registered repo).
-per_week - optional flag switching results to weekly data rather than one row per app for 
+per_week - optional flag switching results to weekly data rather than one row per app for
     all time (default value is false)
 
 
@@ -6940,7 +7121,7 @@ time_range - one of supported time ranges (currently it could be either '*' for 
     or ISO-encoded week like "2016-W01")
 total_queue_time - summarized time difference between exec_start_time and creation_time moments
     defined in seconds since Epoch (POSIX),
-total_exec_time - summarized time difference between finish_time and exec_start_time moments 
+total_exec_time - summarized time difference between finish_time and exec_start_time moments
     defined in seconds since Epoch (POSIX).
 
 
@@ -7060,7 +7241,7 @@ end has a value which is an int
 
 =item Description
 
-app_id = full app id; if module name is used it will be case insensitive 
+app_id = full app id; if module name is used it will be case insensitive
 this will overwrite all existing client groups (it won't just push what's on the list)
 If client_groups is empty or set to null, then the client_group mapping will be removed.
 
@@ -7391,7 +7572,7 @@ data has a value which is a reference to a list where each element is a Catalog.
 
 version - optional version (commit hash, tag or semantic one) of module, if
     not set then default "release" value is used;
-load_all_versions - optional flag indicating that all parameter versions 
+load_all_versions - optional flag indicating that all parameter versions
     should be loaded (version filter is not applied), default value is 0.
 
 

--- a/lib/biokbase/catalog/Client.py
+++ b/lib/biokbase/catalog/Client.py
@@ -41,6 +41,24 @@ class Catalog(object):
         return self._client.call_method('Catalog.version',
                                         [], self._service_ver, context)
 
+    def get_app_resource_estimator(self, params, context=None):
+        """
+        Look up the resource estimator for an app. Always returns the same structure, but the module
+        and method are nulls if no estimator is assigned to that app.
+        :param params: instance of type "GetAppResourceEstimatorParams"
+           (module_name - module with the app of interest app_id - app we're
+           interested in the estimator for tag - release, beta, dev) ->
+           structure: parameter "module_name" of String, parameter "app_id"
+           of String, parameter "tag" of String
+        :returns: instance of type "GetAppResourceEstimatorResults"
+           (estimator_module - module containing the estimator method
+           estimator_method - the estimator method to run tag - release,
+           beta, dev) -> structure: parameter "estimator_module" of String,
+           parameter "estimator_method" of String, parameter "tag" of String
+        """
+        return self._client.call_method('Catalog.get_app_resource_estimator',
+                                        [params], self._service_ver, context)
+
     def is_registered(self, params, context=None):
         """
         returns true (1) if the module exists, false (2) otherwise
@@ -56,7 +74,7 @@ class Catalog(object):
 
     def register_repo(self, params, context=None):
         """
-        allow/require developer to supply git branch/git commit tag? 
+        allow/require developer to supply git branch/git commit tag?
         if this is a new module, creates the initial registration with the authenticated user as
         the sole owner, then launches a build to update the dev version of the module.  You can check
         the state of this build with the 'get_module_state' method passing in the git_url.  If the module

--- a/lib/biokbase/catalog/Impl.py
+++ b/lib/biokbase/catalog/Impl.py
@@ -22,8 +22,8 @@ class Catalog:
     # the latter method is running.
     ######################################### noqa
     VERSION = "0.0.1"
-    GIT_URL = "https://github.com/kbase/catalog.git"
-    GIT_COMMIT_HASH = "c8dcc107f40a9f9a9816c9a5150ee23690a61d6a"
+    GIT_URL = "https://github.com/briehl/catalog"
+    GIT_COMMIT_HASH = "306f2b00ba938d1a42f41237c2ca25b7816406f2"
 
     #BEGIN_CLASS_HEADER
     #END_CLASS_HEADER
@@ -61,6 +61,34 @@ class Catalog:
         # return the results
         return [version]
 
+    def get_app_resource_estimator(self, ctx, params):
+        """
+        Look up the resource estimator for an app. Always returns the same structure, but the module
+        and method are nulls if no estimator is assigned to that app.
+        :param params: instance of type "GetAppResourceEstimatorParams"
+           (module_name - module with the app of interest app_id - app we're
+           interested in the estimator for tag - release, beta, dev) ->
+           structure: parameter "module_name" of String, parameter "app_id"
+           of String, parameter "tag" of String
+        :returns: instance of type "GetAppResourceEstimatorResults"
+           (estimator_module - module containing the estimator method
+           estimator_method - the estimator method to run tag - release,
+           beta, dev) -> structure: parameter "estimator_module" of String,
+           parameter "estimator_method" of String, parameter "tag" of String
+        """
+        # ctx is the context object
+        # return variables are: returnVal
+        #BEGIN get_app_resource_estimator
+        returnVal = self.cc.get_app_resource_estimator(params)
+        #END get_app_resource_estimator
+
+        # At some point might do deeper type checking...
+        if not isinstance(returnVal, dict):
+            raise ValueError('Method get_app_resource_estimator return value ' +
+                             'returnVal is not type dict as required.')
+        # return the results
+        return [returnVal]
+
     def is_registered(self, ctx, params):
         """
         returns true (1) if the module exists, false (2) otherwise
@@ -89,7 +117,7 @@ class Catalog:
 
     def register_repo(self, ctx, params):
         """
-        allow/require developer to supply git branch/git commit tag? 
+        allow/require developer to supply git branch/git commit tag?
         if this is a new module, creates the initial registration with the authenticated user as
         the sole owner, then launches a build to update the dev version of the module.  You can check
         the state of this build with the 'get_module_state' method passing in the git_url.  If the module
@@ -1111,7 +1139,7 @@ class Catalog:
         is_error = params.get('is_error') != 0
         job_id = params.get('job_id')
         self.cc.log_exec_stats(admin_user_id, ctx.get('token'), user_id, app_module_name, app_id, func_module_name,
-                               func_name, git_commit_hash, creation_time, exec_start_time, 
+                               func_name, git_commit_hash, creation_time, exec_start_time,
                                finish_time, is_error, job_id)
         #END log_exec_stats
         pass
@@ -1435,7 +1463,7 @@ class Catalog:
         return [returnVal]
     def status(self, ctx):
         #BEGIN_STATUS
-        returnVal = {'state': "OK", 'message': "", 'version': self.VERSION, 
+        returnVal = {'state': "OK", 'message': "", 'version': self.VERSION,
                      'git_url': self.GIT_URL, 'git_commit_hash': self.GIT_COMMIT_HASH}
         #END_STATUS
         return [returnVal]

--- a/lib/biokbase/catalog/Server.py
+++ b/lib/biokbase/catalog/Server.py
@@ -342,6 +342,10 @@ class Application(object):
                              name='Catalog.version',
                              types=[])
         self.method_authentication['Catalog.version'] = 'none'  # noqa
+        self.rpc_service.add(impl_Catalog.get_app_resource_estimator,
+                             name='Catalog.get_app_resource_estimator',
+                             types=[dict])
+        self.method_authentication['Catalog.get_app_resource_estimator'] = 'none'  # noqa
         self.rpc_service.add(impl_Catalog.is_registered,
                              name='Catalog.is_registered',
                              types=[dict])

--- a/lib/java/us/kbase/catalog/AppClientGroup.java
+++ b/lib/java/us/kbase/catalog/AppClientGroup.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 /**
  * <p>Original spec-file type: AppClientGroup</p>
  * <pre>
- * app_id = full app id; if module name is used it will be case insensitive 
+ * app_id = full app id; if module name is used it will be case insensitive
  * this will overwrite all existing client groups (it won't just push what's on the list)
  * If client_groups is empty or set to null, then the client_group mapping will be removed.
  * </pre>

--- a/lib/java/us/kbase/catalog/CatalogClient.java
+++ b/lib/java/us/kbase/catalog/CatalogClient.java
@@ -180,6 +180,25 @@ public class CatalogClient {
     }
 
     /**
+     * <p>Original spec-file function name: get_app_resource_estimator</p>
+     * <pre>
+     * Look up the resource estimator for an app. Always returns the same structure, but the module
+     * and method are nulls if no estimator is assigned to that app.
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.catalog.GetAppResourceEstimatorParams GetAppResourceEstimatorParams}
+     * @return   instance of type {@link us.kbase.catalog.GetAppResourceEstimatorResults GetAppResourceEstimatorResults}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public GetAppResourceEstimatorResults getAppResourceEstimator(GetAppResourceEstimatorParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<GetAppResourceEstimatorResults>> retType = new TypeReference<List<GetAppResourceEstimatorResults>>() {};
+        List<GetAppResourceEstimatorResults> res = caller.jsonrpcCall("Catalog.get_app_resource_estimator", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
      * <p>Original spec-file function name: is_registered</p>
      * <pre>
      * returns true (1) if the module exists, false (2) otherwise
@@ -200,7 +219,7 @@ public class CatalogClient {
     /**
      * <p>Original spec-file function name: register_repo</p>
      * <pre>
-     * allow/require developer to supply git branch/git commit tag? 
+     * allow/require developer to supply git branch/git commit tag?
      * if this is a new module, creates the initial registration with the authenticated user as
      * the sole owner, then launches a build to update the dev version of the module.  You can check
      * the state of this build with the 'get_module_state' method passing in the git_url.  If the module

--- a/lib/java/us/kbase/catalog/ExecAggrStats.java
+++ b/lib/java/us/kbase/catalog/ExecAggrStats.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  *     or ISO-encoded week like "2016-W01")
  * total_queue_time - summarized time difference between exec_start_time and creation_time moments
  *     defined in seconds since Epoch (POSIX),
- * total_exec_time - summarized time difference between finish_time and exec_start_time moments 
+ * total_exec_time - summarized time difference between finish_time and exec_start_time moments
  *     defined in seconds since Epoch (POSIX).
  * </pre>
  * 

--- a/lib/java/us/kbase/catalog/GetAppResourceEstimatorParams.java
+++ b/lib/java/us/kbase/catalog/GetAppResourceEstimatorParams.java
@@ -1,0 +1,100 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: GetAppResourceEstimatorParams</p>
+ * <pre>
+ * module_name - module with the app of interest
+ * app_id - app we're interested in the estimator for
+ * tag - release, beta, dev
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "module_name",
+    "app_id",
+    "tag"
+})
+public class GetAppResourceEstimatorParams {
+
+    @JsonProperty("module_name")
+    private String moduleName;
+    @JsonProperty("app_id")
+    private String appId;
+    @JsonProperty("tag")
+    private String tag;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("module_name")
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    @JsonProperty("module_name")
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public GetAppResourceEstimatorParams withModuleName(String moduleName) {
+        this.moduleName = moduleName;
+        return this;
+    }
+
+    @JsonProperty("app_id")
+    public String getAppId() {
+        return appId;
+    }
+
+    @JsonProperty("app_id")
+    public void setAppId(String appId) {
+        this.appId = appId;
+    }
+
+    public GetAppResourceEstimatorParams withAppId(String appId) {
+        this.appId = appId;
+        return this;
+    }
+
+    @JsonProperty("tag")
+    public String getTag() {
+        return tag;
+    }
+
+    @JsonProperty("tag")
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public GetAppResourceEstimatorParams withTag(String tag) {
+        this.tag = tag;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("GetAppResourceEstimatorParams"+" [moduleName=")+ moduleName)+", appId=")+ appId)+", tag=")+ tag)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/GetAppResourceEstimatorResults.java
+++ b/lib/java/us/kbase/catalog/GetAppResourceEstimatorResults.java
@@ -1,0 +1,100 @@
+
+package us.kbase.catalog;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: GetAppResourceEstimatorResults</p>
+ * <pre>
+ * estimator_module - module containing the estimator method
+ * estimator_method - the estimator method to run
+ * tag - release, beta, dev
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "estimator_module",
+    "estimator_method",
+    "tag"
+})
+public class GetAppResourceEstimatorResults {
+
+    @JsonProperty("estimator_module")
+    private String estimatorModule;
+    @JsonProperty("estimator_method")
+    private String estimatorMethod;
+    @JsonProperty("tag")
+    private String tag;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("estimator_module")
+    public String getEstimatorModule() {
+        return estimatorModule;
+    }
+
+    @JsonProperty("estimator_module")
+    public void setEstimatorModule(String estimatorModule) {
+        this.estimatorModule = estimatorModule;
+    }
+
+    public GetAppResourceEstimatorResults withEstimatorModule(String estimatorModule) {
+        this.estimatorModule = estimatorModule;
+        return this;
+    }
+
+    @JsonProperty("estimator_method")
+    public String getEstimatorMethod() {
+        return estimatorMethod;
+    }
+
+    @JsonProperty("estimator_method")
+    public void setEstimatorMethod(String estimatorMethod) {
+        this.estimatorMethod = estimatorMethod;
+    }
+
+    public GetAppResourceEstimatorResults withEstimatorMethod(String estimatorMethod) {
+        this.estimatorMethod = estimatorMethod;
+        return this;
+    }
+
+    @JsonProperty("tag")
+    public String getTag() {
+        return tag;
+    }
+
+    @JsonProperty("tag")
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public GetAppResourceEstimatorResults withTag(String tag) {
+        this.tag = tag;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("GetAppResourceEstimatorResults"+" [estimatorModule=")+ estimatorModule)+", estimatorMethod=")+ estimatorMethod)+", tag=")+ tag)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/java/us/kbase/catalog/GetExecAggrStatsParams.java
+++ b/lib/java/us/kbase/catalog/GetExecAggrStatsParams.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <pre>
  * full_app_ids - list of fully qualified app IDs (including module_name prefix followed by
  *     slash in case of dynamically registered repo).
- * per_week - optional flag switching results to weekly data rather than one row per app for 
+ * per_week - optional flag switching results to weekly data rather than one row per app for
  *     all time (default value is false)
  * </pre>
  * 

--- a/lib/java/us/kbase/catalog/GetSecureConfigParamsInput.java
+++ b/lib/java/us/kbase/catalog/GetSecureConfigParamsInput.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <pre>
  * version - optional version (commit hash, tag or semantic one) of module, if
  *     not set then default "release" value is used;
- * load_all_versions - optional flag indicating that all parameter versions 
+ * load_all_versions - optional flag indicating that all parameter versions
  *     should be loaded (version filter is not applied), default value is 0.
  * </pre>
  * 

--- a/lib/java/us/kbase/catalog/ListFavoriteCounts.java
+++ b/lib/java/us/kbase/catalog/ListFavoriteCounts.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <pre>
  * if favorite item is given, will return stars just for that item.  If a module
  * name is given, will return stars for all methods in that module.  If none of
- * those are given, then will return stars for every method that there is info on 
+ * those are given, then will return stars for every method that there is info on
  * parameters to add:
  *     list<FavoriteItem> items;
  * </pre>

--- a/lib/java/us/kbase/catalog/ModuleInfo.java
+++ b/lib/java/us/kbase/catalog/ModuleInfo.java
@@ -46,12 +46,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -63,12 +63,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -80,12 +80,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -174,12 +174,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -194,12 +194,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -219,12 +219,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -239,12 +239,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -264,12 +264,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 
@@ -284,12 +284,12 @@ public class ModuleInfo {
      * <pre>
      * data_folder - optional field representing unique module name (like <module_name> transformed to
      *     lower cases) used for reference data purposes (see description for data_version field). This
-     *     value will be treated as part of file system path relative to the base that comes from the 
+     *     value will be treated as part of file system path relative to the base that comes from the
      *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
-     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+     * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
      *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
      *     should be initialized by running docker image with "init" target from catalog. And later when
-     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+     *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
      *     docker container by execution engine.
      * </pre>
      * 

--- a/lib/java/us/kbase/catalog/ModuleVersion.java
+++ b/lib/java/us/kbase/catalog/ModuleVersion.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * narrative_app_ids      - list of Narrative App ids registered with this module version
  * local_function_ids     - list of Local Function ids registered with this module version
  * docker_img_name        - name of the docker image for this module created on registration
- * data_folder            - name of the data folder used 
+ * data_folder            - name of the data folder used
  * compilation_report     - (optionally returned) summary of the KIDL specification compilation
  * </pre>
  * 

--- a/lib/java/us/kbase/catalog/ModuleVersionInfo.java
+++ b/lib/java/us/kbase/catalog/ModuleVersionInfo.java
@@ -17,12 +17,12 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * <pre>
  * data_folder - optional field representing unique module name (like <module_name> transformed to
  *     lower cases) used for reference data purposes (see description for data_version field). This
- *     value will be treated as part of file system path relative to the base that comes from the 
+ *     value will be treated as part of file system path relative to the base that comes from the
  *     config (currently base is supposed to be "/kb/data" defined in "ref-data-base" parameter).
- * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version" 
+ * data_version - optional field, reflects version of data defined in kbase.yml (see "data-version"
  *     key). In case this field is set data folder with path "/kb/data/<data_folder>/<data_version>"
  *     should be initialized by running docker image with "init" target from catalog. And later when
- *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside 
+ *     async methods are run it should be mounted on AWE worker machine into "/data" folder inside
  *     docker container by execution engine.
  * </pre>
  * 

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -30,6 +30,19 @@ function Catalog(url, auth, auth_cb, timeout, async_job_check_time_ms, service_v
             [], 1, _callback, _errorCallback);
     };
  
+     this.get_app_resource_estimator = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "Catalog.get_app_resource_estimator",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
      this.is_registered = function (params, _callback, _errorCallback) {
         if (typeof params === 'function')
             throw 'Argument params can not be a function';

--- a/test/app_estimator_test.py
+++ b/test/app_estimator_test.py
@@ -1,0 +1,50 @@
+import unittest
+from biokbase.catalog.Impl import Catalog
+from biokbase.narrative_method_store.client import NarrativeMethodStore
+from catalog_test_util import CatalogTestUtil
+from biokbase.catalog.baseclient import ServerError
+
+class AppEstimatorTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+
+        print('++++++++++++ RUNNING core_registration_test.py +++++++++++')
+
+        cls.cUtil = CatalogTestUtil('.')  # TODO: pass in test directory from outside
+        cls.cUtil.setUp()
+        cls.catalog = Catalog(cls.cUtil.getCatalogConfig())
+        # approve developers we will use
+        cls.catalog.approve_developer(cls.cUtil.admin_ctx(), cls.cUtil.admin_ctx()['user_id'])
+        cls.catalog.approve_developer(cls.cUtil.admin_ctx(), cls.cUtil.user_ctx()['user_id'])
+
+        cls.nms = NarrativeMethodStore(cls.cUtil.getCatalogConfig()['nms-url'])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cUtil.tearDown()
+
+    def test_get_estimator_null(self):
+        app_id = "annotate_contigset"
+        res = self.catalog.get_app_resource_estimator(self.cUtil.user_ctx(), {
+            "app_id": app_id
+        })[0]
+        self.assertIsNone(res.get("estimator_module"))
+        self.assertIsNone(res.get("estimator_method"))
+        self.assertIsNone(res.get("tag"))
+
+    def test_get_estimator_fail(self):
+        app_id = "not_real"
+        with self.assertRaises(ValueError) as e:
+            self.catalog.get_app_resource_estimator(self.cUtil.user_ctx(), {
+                "app_id": app_id
+            })
+        self.assertIn(f"App {app_id} with tag release doesn't seem to exist.", str(e.exception))
+
+    def test_get_estimator(self):
+        app_id = "annotate_contigset"
+        res = self.catalog.get_app_resource_estimator(self.cUtil.user_ctx(), {
+            "app_id": app_id
+        })[0]
+        self.assertEqual(res.get("estimator_module"), "EstimatorModule")
+        self.assertEqual(res.get("estimator_method"), "estimate_resources")
+        self.assertEqual(res.get("tag"), "release")

--- a/test/app_estimator_test.py
+++ b/test/app_estimator_test.py
@@ -24,7 +24,7 @@ class AppEstimatorTestCase(unittest.TestCase):
         cls.cUtil.tearDown()
 
     def test_get_estimator_null(self):
-        app_id = "annotate_contigset"
+        app_id = "test_method_1"
         res = self.catalog.get_app_resource_estimator(self.cUtil.user_ctx(), {
             "app_id": app_id
         })[0]
@@ -41,10 +41,10 @@ class AppEstimatorTestCase(unittest.TestCase):
         self.assertIn(f"App {app_id} with tag release doesn't seem to exist.", str(e.exception))
 
     def test_get_estimator(self):
-        app_id = "annotate_contigset"
+        app_id = "test_method_11"
         res = self.catalog.get_app_resource_estimator(self.cUtil.user_ctx(), {
             "app_id": app_id
         })[0]
-        self.assertEqual(res.get("estimator_module"), "EstimatorModule")
-        self.assertEqual(res.get("estimator_method"), "estimate_resources")
+        self.assertEqual(res.get("estimator_module"), "SomeService")
+        self.assertEqual(res.get("estimator_method"), "estimator_method")
         self.assertEqual(res.get("tag"), "release")

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -19,7 +19,7 @@ echo 'Starting Mock Auth API...'
 docker run -d --rm -v ${PWD}/mock_auth:/config -p 7777:5000 --name mock-auth mockservices/mock_json_service:1
 
 echo 'Waiting for NMS to start...'
-sleep 25
+sleep 100
 curl -d '{"id":"1","params":[],"method":"NarrativeMethodStore.ver","version":"1.1"}' http://localhost:7125
 if [ $? -ne 0 ]; then
     kill -9 $NMS_PID

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -16,7 +16,7 @@ java -cp $classpath us.kbase.narrativemethodstore.NarrativeMethodStoreServer 712
 NMS_PID=$!
 
 echo 'Starting Mock Auth API...'
-docker run -d --rm -v ${PWD}/mock_auth:/config -p 7777:5000 --name mock-auth mockservices/mock_json_service
+docker run -d --rm -v ${PWD}/mock_auth:/config -p 7777:5000 --name mock-auth mockservices/mock_json_service:1
 
 echo 'Waiting for NMS to start...'
 sleep 25

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -19,7 +19,7 @@ echo 'Starting Mock Auth API...'
 docker run -d --rm -v ${PWD}/mock_auth:/config -p 7777:5000 --name mock-auth mockservices/mock_json_service:1
 
 echo 'Waiting for NMS to start...'
-sleep 100
+sleep 30
 curl -d '{"id":"1","params":[],"method":"NarrativeMethodStore.ver","version":"1.1"}' http://localhost:7125
 if [ $? -ne 0 ]; then
     kill -9 $NMS_PID


### PR DESCRIPTION
similar to other app lookup functions in catalog, can be run with:

```
catalog.get_app_resource_estimator({
    "module_name": "SomeModule",
    "app_id": "some_method",
    "tag": "release"
})
```
or 
```
catalog.get_app_resource_estimator({
    "app_id": "some_nms_only_module"  # or "SomeModule.some_method"
})
```

returns
```
{
    "estimator_module": "SomeModule",
    "estimator_method": "an_estimator_method"
    "tag": "release"  # (or "beta" or "dev")
}
```

If an estimator isn't found, those values are null.

To get this to work right, I changed two things for testing.
1. Changed the NMS submodule to the `develop` branch (that's only used for testing anyway)
2. Changed the narrative_method_specs it uses to the `test` branch, which it should probably be using anyway.

Other than that, it's pretty straightforward. Main changes are in `catalog.spec`, `controller.py`, and `app_estimator_test.py`